### PR TITLE
Change Grub options: remove console=ttyS0

### DIFF
--- a/srv_fai_config/files/etc/default/grub.d/20_efi_ipv6.cfg/SEAPATH
+++ b/srv_fai_config/files/etc/default/grub.d/20_efi_ipv6.cfg/SEAPATH
@@ -1,0 +1,1 @@
+GRUB_CMDLINE_LINUX_DEFAULT="efi=runtime ipv6.disable=1"

--- a/srv_fai_config/files/etc/default/grub.d/20_ttyS0.cfg/SEAPATH
+++ b/srv_fai_config/files/etc/default/grub.d/20_ttyS0.cfg/SEAPATH
@@ -1,1 +1,0 @@
-GRUB_CMDLINE_LINUX_DEFAULT="efi=runtime console=ttyS0 console=tty1 ipv6.disable=1"

--- a/srv_fai_config/scripts/SEAPATH/20-grub_default
+++ b/srv_fai_config/scripts/SEAPATH/20-grub_default
@@ -7,5 +7,5 @@ error=0; trap 'error=$(($?>$error?$?:$error))' ERR # save maximum error code
 #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863385
 #   https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
 
-fcopy -M /etc/default/grub.d/20_ttyS0.cfg
+fcopy -M /etc/default/grub.d/20_efi_ipv6.cfg
 $ROOTCMD update-grub


### PR DESCRIPTION
Having console=ttyS0 in the kernel boot parameters was useful for
testing on virtual machines ("virsh console" uses ttyS0...) however it
is problematic on real hardware.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>