### PR TITLE
packages: add dns/kerberos and remove nullmailer

### DIFF
--- a/srv_fai_config/package_config/SEAPATH
+++ b/srv_fai_config/package_config/SEAPATH
@@ -56,3 +56,10 @@ sysfsutils
 dstat
 sysstat
 linuxptp
+bind9-dnsutils
+krb5-user
+ldap-utils
+libsasl2-modules-gssapi-mit
+
+PACKAGES remove
+nullmailer


### PR DESCRIPTION
Kerberos packages are useful to be able to join the seapath machines to
a ActiveDirectory domain.
Nullmailer is (for now) not used, and is installed by default. This
makes the machines try to resolve the "mail" hostname all the time.
Removing the package is the simplest solution.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>