### PR TITLE
remove dracut from package list

### DIFF
--- a/srv_fai_config/package_config/SEAPATH
+++ b/srv_fai_config/package_config/SEAPATH
@@ -49,7 +49,6 @@ bridge-utils
 cpuset
 linux-image-rt-amd64/bullseye-backports
 irqbalance
-dracut
 lbzip2
 sysfsutils
 dstat


### PR DESCRIPTION
this package comes with heavy dependancies (gcc..) and is not actually usefull for SEAPATH.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>