### PR TITLE
remove a useless mv operation

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -18,8 +18,7 @@ docker cp $wd/srv_fai_config/. fai-setup:/ext/srv/fai/config/
 # Adding the php:apache docker image
 docker pull php:apache
 mkdir -p /tmp/php_image/opt/php_apache.tgz
-docker save php:apache | gzip > /tmp/php_image/opt/php_apache.tgz/SEAPATH.tgz
-mv /tmp/php_image/opt/php_apache.tgz/SEAPATH.tgz /tmp/php_image/opt/php_apache.tgz/SEAPATH
+docker save php:apache | gzip > /tmp/php_image/opt/php_apache.tgz/SEAPATH
 echo docker cp /tmp/php_image/. fai-setup:/ext/src/fai/files/
 docker cp /tmp/php_image/. fai-setup:/ext/srv/fai/config/files/
 rm -rf /tmp/php_image/


### PR DESCRIPTION
we can write the file directly to the correct name and get rid of this extra "mv" operation

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>