### PR TITLE
increase the /boot partition to 500MB

### DIFF
--- a/srv_fai_config/disk_config/SEAPATH_LVM
+++ b/srv_fai_config/disk_config/SEAPATH_LVM
@@ -4,7 +4,7 @@
 
 disk_config disk1 fstabkey:uuid align-at:1M
 
-primary /boot	200	ext2	rw,noatime
+primary /boot	500	ext2	rw,noatime
 primary -       4G-	-       -
 
 disk_config lvm

--- a/srv_fai_config/disk_config/SEAPATH_LVM_EFI
+++ b/srv_fai_config/disk_config/SEAPATH_LVM_EFI
@@ -5,7 +5,7 @@
 disk_config disk1 disklabel:gpt fstabkey:uuid align-at:1M
 
 primary /boot/efi 512M  vfat    rw
-primary /boot	200	ext2	rw,noatime
+primary /boot	500	ext2	rw,noatime
 primary -       10G	-       -
 
 disk_config lvm


### PR DESCRIPTION
The initrd file of the new kernel v6 is almost 50MB (it used to be 18MB on the v5 kernel).
This can saturate the /boot partition and make the upgrade fail. 500MB instead of 200MB for the /boot partition seems appropriate

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>