### PR TITLE
Set defaut networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ more information about password hash : https://linuxconfig.org/how-to-hash-passw
 **other changes in `srv_fai_config/class/SEAPATH.var`**
 * TIMEZONE, KEYMAP, apt_cdn: feel free to set you regionalized settings, it's all too french by default :)
 * APTPROXY: in case your deployed host will need some proxy to access the debian mirror
+* REMOTENIC, REMOTEADDR, REMOTEGW: if you want networking to be available right after deployement set ip/gateway to a specified niv (ie: ens0, enp0s1...)
 * SERVER, LOGUSER: if you want the installation logs to be uploaded, using SCP, to a server, for which the login username will be LOGUSER and the password "fai"
 
 more info: https://fai-project.org/fai-guide

--- a/srv_fai_config/class/SEAPATH.var
+++ b/srv_fai_config/class/SEAPATH.var
@@ -29,3 +29,7 @@ USERPW='$y$j9T$s.szNr.QzTLk8h5qMYDpo0$YMaC8.04FilI/1AguyofvbV4FH1me6Nc7SHP4hyefZ
 apt_cdn=http://ftp.fr.debian.org
 SERVER=192.168.122.3
 LOGUSER=fai
+
+#REMOTENIC=
+#REMOTEADDR=
+#REMOTEGW=

--- a/srv_fai_config/scripts/SEAPATH/40-networking
+++ b/srv_fai_config/scripts/SEAPATH/40-networking
@@ -20,3 +20,16 @@ $ROOTCMD chown -R root:root /root/.ssh
 $ROOTCMD chown -R $username:$username /home/$username/.ssh
 $ROOTCMD chown -R $usernameansible:$usernameansible /home/$usernameansible/.ssh
 $ROOTCMD chmod 600 /home/$username/.ssh/authorized_keys /root/.ssh/authorized_keys /home/$usernameansible/.ssh/authorized_keys
+
+if [ -n "${REMOTENIC+x}" ] && [ -n "${REMOTEADDR+x}" ] && [ -n "${REMOTEGW+x}" ]
+then
+  cat <<EOF > $target/etc/systemd/network/00-init.network
+[Match]
+Name=$REMOTENIC
+[Network]
+Address=$REMOTEADDR
+Gateway=$REMOTEGW
+EOF
+fi
+
+$ROOTCMD chmod 644 /etc/systemd/network/00-init.network


### PR DESCRIPTION
This commit allow the user to configure ip addressing to a specified NIC so that remote access to the deployed server is possible right after deployment.
Along with the "no menu" feature that uses the SEAPATH_LVM profile by default, this allows a host to be deployed without even having to plug a screen and keyboard.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>