### PR TITLE
Allow the SEAPATH_LVM profile to be loaded by default

### DIFF
--- a/etc_fai/grub.cfg
+++ b/etc_fai/grub.cfg
@@ -39,7 +39,7 @@ set timeout=20
 
 menuentry "Client standalone installation - select installation type from menu " {
     search --set=root --file /FAI-CD
-    linux   /boot/vmlinuz FAI_FLAGS="menu,verbose,sshd,createvt" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1
+    linux   /boot/vmlinuz FAI_FLAGS="verbose,sshd,createvt" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1
     initrd  /boot/initrd.img
 }
 

--- a/srv_fai_config/class/50-seapath
+++ b/srv_fai_config/class/50-seapath
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+# do not use this if a menu will be presented
+[ "$flag_menu" ] && exit 0
+
+echo "SEAPATH_LVM SEAPATH"


### PR DESCRIPTION
Without this patch, the deployment needs a user to be physically connecter to the server (with keyboard and screen) to choose the profile.
With this commit, the SEAPATH_LVM profile is loaded by default. An upcoming commit will allow the user to preset an ip address on a specific NIC so that network is available right after deployement.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>