### PR TITLE
replace timesyncd by chronyd

### DIFF
--- a/srv_fai_config/package_config/SEAPATH
+++ b/srv_fai_config/package_config/SEAPATH
@@ -41,7 +41,7 @@ docker.io
 docker-compose
 metricbeat
 filebeat
-systemd-timesyncd
+chrony
 qemu-utils
 snmpd
 ovmf


### PR DESCRIPTION
To allow seapath to use ntp or ptp, the target system will use timemaster (provided by linuxptp).
Timemaster uses chrony to sync the hwclock with multiple clock (ptp, ntp)
The ansible playbooks will need to be updated.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>