### PR TITLE
Reboot automatically after deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,3 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install fai-server fai-doc && \
     apt-get -y install reprepro xorriso squashfs-tools vim
-ADD etc_fai /etc/fai/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
     volumes:
       - ext:/ext
+      - ./etc_fai:/etc/fai:ro
     cap_add:
       - SYS_ADMIN
     security_opt:
@@ -18,6 +19,7 @@ services:
       context: .
     volumes:
       - ext:/ext
+      - ./etc_fai:/etc/fai:ro
     privileged: true
     container_name: fai-cd
 volumes:

--- a/etc_fai/grub.cfg
+++ b/etc_fai/grub.cfg
@@ -39,7 +39,7 @@ set timeout=20
 
 menuentry "Client standalone installation - select installation type from menu " {
     search --set=root --file /FAI-CD
-    linux   /boot/vmlinuz FAI_FLAGS="verbose,sshd,createvt" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1
+    linux   /boot/vmlinuz FAI_FLAGS="verbose,sshd,createvt,reboot" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1
     initrd  /boot/initrd.img
 }
 


### PR DESCRIPTION
A precedent commit allowed the deployment to start without the user to even to press enter.
Another one allowed the user to preconfigure a network configuration. With all that it should be possible to deploy a node without even having to plug a screen and keyboard on the machine.
However there still is the need to press ENTER at the end of the deployment, just before the reboot.
This commit fixes this by automating the end of deployment reboot.

The change is in the grub configuration, which was included in the docker image. This means to be taken into account, this fix would require the user to rebuild the docker image, which is painful. In order to change this, this commit also removes the /etc/fai configuration from the docker image and mount it as a container volume. That way any change in the /etc/fai configuration is effective without having to rebuild the image.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>