### PR TITLE
fai: remove all LVM volume groups before install

### DIFF
--- a/srv_fai_config/hooks/install.SEAPATH
+++ b/srv_fai_config/hooks/install.SEAPATH
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+vgs -o vg_name --noheadings | while read i
+do
+  vgremove -f $i
+done


### PR DESCRIPTION
FAI may choke when trying to remove the existing lvm volume groups, for instance when there are snapshots.
This commit makes the iso remove all the existing lvm volume groups before FAI starts the installation.