### PR TITLE
Disable Timemaster service

### DIFF
--- a/srv_fai_config/scripts/SEAPATH/60-misc
+++ b/srv_fai_config/scripts/SEAPATH/60-misc
@@ -4,5 +4,6 @@ error=0; trap 'error=$(($?>$error?$?:$error))' ERR # save maximum error code
 
 $ROOTCMD systemctl disable corosync.service
 $ROOTCMD systemctl disable pacemaker.service
+$ROOTCMD systemctl disable timemaster.service
 
 $ROOTCMD apt -y autoremove


### PR DESCRIPTION
When the host is not configured (networking, ntp...) then timemaster can take several minutes to shutdown, which will make the host wait ages to reboot.
We disable timemaster service here, it will be re-enabled with the networking ansible playbook.