### PR TITLE
remove vim from SEAPATH_DBG

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_DBG
+++ b/srv_fai_config/package_config/SEAPATH_DBG
@@ -11,4 +11,3 @@ screen
 stress-ng
 sysfsutils
 tcpdump
-vim


### PR DESCRIPTION
Since vim is now in SEAPATH_COMMON