### PR TITLE
Force debian11 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:11
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install fai-server fai-doc fai-setup-storage && \


### PR DESCRIPTION
Debian has upgraded to v12, with changes to the FAI version.
This codebase is (for now) only compatible with debian11.