### PR TITLE
Silly typos

### DIFF
--- a/srv_fai_config/class/SEAPATH_COMMON.var.defaults
+++ b/srv_fai_config/class/SEAPATH_COMMON.var.defaults
@@ -1,5 +1,7 @@
 # default values for installation. You can override them in your *.var files
 
+release=bullseye
+secsuite=$release-security
 # allow installation of packages from unsigned repositories
 FAI_ALLOW_UNSIGNED=0
 

--- a/srv_fai_config/disk_config/SEAPATH_RAID
+++ b/srv_fai_config/disk_config/SEAPATH_RAID
@@ -12,9 +12,9 @@ primary    -           300G  -     -
 
 disk_config lvm
 vg vg1      disk1.2,disk2.2
-vg1-root        /            20G   ext4    noatime,rw  lvcreateopts="-m 1 --type raid1 --nosync" createopts="-N 256"
+vg1-root        /            20G   ext4    noatime,rw  lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 vg1-swap        swap          2G   swap    sw          lvcreateopts="-m 1 --type raid1 --nosync"
-vg1-log         /var/log      5G   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-N 256"
+vg1-log         /var/log      5G   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 
 vg vg_ceph  disk1.3,disk2.3
 vg_ceph-lv_ceph -           200G   -       -           lvcreateopts="-m 1 --type raid1 --nosync"


### PR DESCRIPTION
- vars: change bookworm to bullseye to defaults vars : this will define the apt/sources.list file of the deployed machine
- ext4 inode: the correct option is -I and not -N