### PR TITLE
merge waiting changes

### DIFF
--- a/srv_fai_config/class/BOOKWORM64.var
+++ b/srv_fai_config/class/BOOKWORM64.var
@@ -1,0 +1,2 @@
+release=bookworm
+secsuite=$release-security

--- a/srv_fai_config/class/BULLSEYE64.var
+++ b/srv_fai_config/class/BULLSEYE64.var
@@ -1,0 +1,2 @@
+release=bullseye
+secsuite=$release-security

--- a/srv_fai_config/class/SEAPATH_COMMON.var.defaults
+++ b/srv_fai_config/class/SEAPATH_COMMON.var.defaults
@@ -1,7 +1,5 @@
 # default values for installation. You can override them in your *.var files
 
-release=bullseye
-secsuite=$release-security
 # allow installation of packages from unsigned repositories
 FAI_ALLOW_UNSIGNED=0
 

--- a/srv_fai_config/class/SEAPATH_COMMON.var.defaults
+++ b/srv_fai_config/class/SEAPATH_COMMON.var.defaults
@@ -47,3 +47,6 @@ REMOTEGW=10.0.0.1
 # all: DHCP will be enable for all interface
 # [interface]: DHCP will be enable for the interface. e.g enp1s0
 REMOTEDHCP=no
+
+# You should customize the disk list depending on your hardware.
+#disklist="disk/by-path/pci-0000:c3:00.0-scsi-0:0:0:0 disk/by-path/pci-0000:c3:00.0-scsi-0:0:1:0 "

--- a/srv_fai_config/disk_config/SEAPATH_HOST
+++ b/srv_fai_config/disk_config/SEAPATH_HOST
@@ -5,11 +5,11 @@
 disk_config disk1 disklabel:gpt fstabkey:uuid align-at:1M
 
 primary /boot/efi  512M  vfat    rw
-primary -           10G	 -       -
+primary -          100G	 -       -
 
 disk_config lvm
 
 vg vg1  disk1.2
-vg1-root    /         7G      ext4    noatime,rw
-vg1-varlog  /var/log  1G      ext4    noatime,rw
-vg1-swap    swap      500     swap    sw
+vg1-root    /          15G      ext4    noatime,rw
+vg1-varlog  /var/log    5G      ext4    noatime,rw
+vg1-swap    swap      500M      swap    sw

--- a/srv_fai_config/package_config/SEAPATH_COMMON
+++ b/srv_fai_config/package_config/SEAPATH_COMMON
@@ -29,6 +29,7 @@ lvm2
 net-tools
 openssh-server
 ovmf
+parted
 python3-apt
 python3-cffi-backend
 python3-setuptools

--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -10,6 +10,7 @@ ceph-mon
 ceph-osd
 corosync
 crmsh
+ipmitool
 libcephfs2
 libvirt-clients
 libvirt-daemon


### PR DESCRIPTION
class: add bullseye and bookworm class for repo configuration

The list of repos in the /etc/apt/sources.list of the deployed machine will depends on those variables.
We add them in classes instead of the user having to specify this in its customization var file.

----

custom vars: customizing disklist

the scsi ordering in linux may not be deterministic (/dev/sda and /dev/sdb may switch depending on the hardware).
You can now customize the disklist by using /dev/disk/by-path/ links.

----

SEAPATH_HOST: add ipmitool

----

SEAPATH_COMMON: add parted package

parted is a dependency of ceph so is already present in SEAPATH_HOST but will be useful in SEAPATH_VM so that the customer can use ansible parted module to customize its guest partitionning.
cfdisk is present by default but there is no ansible module for it.