### PR TITLE
vlan on remote network

### DIFF
--- a/srv_fai_config/class/SEAPATH_COMMON.var.defaults
+++ b/srv_fai_config/class/SEAPATH_COMMON.var.defaults
@@ -41,6 +41,8 @@ apt_cdn=http://ftp.fr.debian.org
 REMOTENIC=enp1s0
 REMOTEADDR=10.0.0.2/24
 REMOTEGW=10.0.0.1
+# you can set the ip on a vlan interface
+#REMOTEVLANID=159
 
 # network configuration dhcp
 # No: DHCP will be disable

--- a/srv_fai_config/scripts/SEAPATH_COMMON/40-networking
+++ b/srv_fai_config/scripts/SEAPATH_COMMON/40-networking
@@ -25,14 +25,41 @@ set +x
 
 if [ -n "${REMOTENIC+x}" ] && [ -n "${REMOTEADDR+x}" ] && [ -n "${REMOTEGW+x}" ]
 then
-  cat <<EOF > $target/etc/systemd/network/01-init.network
+  if [ -n "${REMOTEVLANID+x}" ] && [[ ${REMOTEVLANID} =~ ^[0-9]+$ ]]
+  then
+    cat <<EOF > $target/etc/systemd/network/01-vlan.netdev
+[NetDev]
+Name=vlan${REMOTEVLANID}
+Kind=vlan
+[VLAN]
+Id=${REMOTEVLANID}
+EOF
+    $ROOTCMD chmod 644 /etc/systemd/network/01-vlan.netdev
+    cat <<EOF > $target/etc/systemd/network/01-vlan.network
+[Match]
+Name=vlan${REMOTEVLANID}
+[Network]
+Address=$REMOTEADDR
+Gateway=$REMOTEGW
+EOF
+    $ROOTCMD chmod 644 /etc/systemd/network/01-vlan.network
+    cat <<EOF > $target/etc/systemd/network/01-init.network
+[Match]
+Name=$REMOTENIC
+[Network]
+VLAN=vlan${REMOTEVLANID}
+EOF
+    $ROOTCMD chmod 644 /etc/systemd/network/01-init.network
+  else
+    cat <<EOF > $target/etc/systemd/network/01-init.network
 [Match]
 Name=$REMOTENIC
 [Network]
 Address=$REMOTEADDR
 Gateway=$REMOTEGW
 EOF
-  $ROOTCMD chmod 644 /etc/systemd/network/01-init.network
+    $ROOTCMD chmod 644 /etc/systemd/network/01-init.network
+  fi
 fi
 
 if [ -n "${REMOTEDHCP}" ] && [ "${REMOTEDHCP,,}" != "no" ] ;then


### PR DESCRIPTION
Build_debian_iso configures the main network interface of the host so that host is directly accessible via networking after deployment.
In some network topologies, this main host network interface is a trunk, and the host needs to support vlan tagging to get access to the network.
This commit makes this topology supported, throught the use of the "REMOTEVLANID" configuration variable (in which the user simply has to set the vlanid number).