### PR TITLE
Debian12 upgrade

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -13,7 +13,8 @@ set -ex
 # Creating the NFSROOT
 # Removing *.profile since we don't use them
 # Removing 50-host-classes to prevent DEMO and FAIBASE to be added to the list of classes
-# Adding the Bullseye basefiles to that we deploy a Debian v11 distro
+# Adding the Bookworm basefiles to that we deploy a Debian v12 distro
+# Patches /sbin/install_packages (bug in the process of being corrected upstream)
 docker-compose -f $wd/docker-compose.yml run --rm fai-setup bash -c "\
     echo \"fai-setup -v -e -f \" && \
     fai-setup -v -e -f && \
@@ -21,8 +22,11 @@ docker-compose -f $wd/docker-compose.yml run --rm fai-setup bash -c "\
     rm -f /ext/srv/fai/config/class/50-host-classes && \
     echo \"rm -f /ext/srv/fai/config/class/*.profile\" && \
     rm -f /ext/srv/fai/config/class/*.profile && \
-    echo \"wget -O /ext/srv/fai/config/basefiles/BULLSEYE64.tar.xz https://fai-project.org/download/basefiles/BULLSEYE64.tar.xz\" && \
-    wget -O /ext/srv/fai/config/basefiles/BULLSEYE64.tar.xz https://fai-project.org/download/basefiles/BULLSEYE64.tar.xz"
+    echo \"SED\" && \
+    sed -i -e \"s|-f \\\"\$FAI_ROOT/var/cache/apt/pkgcache\.bin|-d \\\"\$FAI_ROOT/var/lib/apt/lists|\" /ext/nfsroot/sbin/install_packages && \
+    sed -i -e \"s/ --allow-change-held-packages//\" /ext/nfsroot/sbin/install_packages && \
+    echo \"wget -O /ext/srv/fai/config/basefiles/BOOKWORM64.tar.xz https://fai-project.org/download/basefiles/BOOKWORM64.tar.xz\" && \
+    wget -O /ext/srv/fai/config/basefiles/BOOKWORM64.tar.xz https://fai-project.org/download/basefiles/BOOKWORM64.tar.xz"
 
 # Starting the container to add stuff in it
 docker-compose -f $wd/docker-compose.yml up --no-start fai-setup

--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -24,10 +24,10 @@ docker cp $wd/srv_fai_config/. fai-setup:ext/srv/fai/config/
 docker-compose -f $wd/docker-compose.yml down
 
 # Creating the VM
-# patches /sbin/install_packages in build_qcow2.sh to make bookwork fai-diskimage able to create a bullseye iso
-CLASSES="DEBIAN,FAIBASE,FRENCH,BULLSEYE64,SEAPATH_COMMON,SEAPATH_VM,GRUB_EFI,LAST"
+# patches /sbin/install_packages (bug in the process of being corrected upstream)
+CLASSES="DEBIAN,FAIBASE,FRENCH,BOOKWORM64,SEAPATH_COMMON,SEAPATH_VM,GRUB_EFI,LAST"
 docker-compose -f $wd/docker-compose.yml run --rm -e FAI_BASEFILEURL=https://fai-project.org/download/basefiles/ fai-cd bash -c "\
-  sed -i -e \"s/-f \\\"\\\$FAI_ROOT\\/var\\/cache\\/apt\\/pkgcache\\.bin/-d \\\"\\\$FAI_ROOT\\/var\\/lib\\/apt\\/lists/\" /sbin/install_packages && \
+  sed -i -e \"s|-f \\\"\\\$FAI_ROOT/var/cache/apt/pkgcache\.bin|-d \\\"\\\$FAI_ROOT/var/lib/apt/lists|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   fai-diskimage -vu seapath-vm -S10G -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"
 

--- a/etc_fai/NFSROOT
+++ b/etc_fai/NFSROOT
@@ -56,7 +56,7 @@ grub-pc
 grub-efi-amd64-bin
 efibootmgr
 linux-image-amd64
-#linux-image-amd64/bullseye-backports # if you want to use a newer kernel
+#linux-image-amd64/bookworm-backports # if you want to use a newer kernel
 
 PACKAGES install-norec ARM64
 grub-efi-arm64

--- a/etc_fai/apt/sources.list
+++ b/etc_fai/apt/sources.list
@@ -1,11 +1,11 @@
 # These lines should work for many sites
 
-deb http://ftp.fr.debian.org/debian bullseye main contrib non-free
-deb http://ftp.fr.debian.org/debian-security bullseye-security main contrib non-free
-deb http://ftp.fr.debian.org/debian bullseye-backports main contrib non-free
+deb http://ftp.fr.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://ftp.fr.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+deb http://ftp.fr.debian.org/debian bookworm-backports main contrib non-free
 
-# repository that may contain newer fai packages for bullseye
-deb [arch=amd64] http://fai-project.org/download bullseye koeln
+# repository that may contain newer fai packages for bookworm
+deb [arch=amd64] http://fai-project.org/download bookworm koeln
 
 #Elastic
 deb [arch=amd64] https://artifacts.elastic.co/packages/8.x/apt stable main

--- a/etc_fai/grub.cfg
+++ b/etc_fai/grub.cfg
@@ -52,6 +52,11 @@ menuentry "SEAPATH installation - RAID, no kerberos, no debug tools" {
     linux   /boot/vmlinuz FAI_FLAGS="raid,verbose,sshd,createvt,reboot" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1
     initrd  /boot/initrd.img
 }
+menuentry "SEAPATH installation - RAIDDEMO TTYS0, no kerberos, no debug tools" {
+    search --set=root --file /FAI-CD
+    linux   /boot/vmlinuz FAI_FLAGS="raiddemo,verbose,sshd,createvt,reboot" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=ttyS0
+    initrd  /boot/initrd.img
+}
 menuentry "SEAPATH installation - no raid, KERBEROS, no debug tools" {
     search --set=root --file /FAI-CD
     linux   /boot/vmlinuz FAI_FLAGS="kerberos,verbose,sshd,createvt,reboot" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1

--- a/etc_fai/nfsroot.conf
+++ b/etc_fai/nfsroot.conf
@@ -1,7 +1,7 @@
 # For a detailed description see nfsroot.conf(5)
 
 # "<suite> <mirror>" for debootstrap
-FAI_DEBOOTSTRAP="bullseye http://ftp.fr.debian.org/debian"
+FAI_DEBOOTSTRAP="bookworm http://ftp.fr.debian.org/debian"
 FAI_ROOTPW='$1$kBnWcO.E$djxB128U7dMkrltJHPf6d1'
 
 NFSROOT=/ext/nfsroot

--- a/srv_fai_config/class/99-seapath
+++ b/srv_fai_config/class/99-seapath
@@ -3,7 +3,7 @@
 # do not use this if a menu will be presented
 [ "$flag_menu" ] && exit 0
 
-echo DEBIAN FAIBASE FRENCH BULLSEYE64 SEAPATH_COMMON SEAPATH_HOST
+echo DEBIAN FAIBASE FRENCH BOOKWORM64 SEAPATH_COMMON SEAPATH_HOST
 
 [ "$flag_raid" ] && echo "SEAPATH_RAID"
 [ "$flag_raiddemo" ] && echo "SEAPATH_RAID SEAPATH_RAID_DEMO"

--- a/srv_fai_config/package_config/SEAPATH_COMMON
+++ b/srv_fai_config/package_config/SEAPATH_COMMON
@@ -15,13 +15,12 @@ dstat
 efibootmgr
 gnupg
 grub-efi-amd64-signed
-hddtemp
 intel-microcode
 iptables-persistent
 irqbalance
 jq
 lbzip2
-linux-image-rt-amd64/bullseye-backports
+linux-image-rt-amd64/bookworm-backports
 linuxptp
 lm-sensors
 lsb-release
@@ -38,6 +37,7 @@ sudo
 sysfsutils
 syslog-ng
 sysstat
+systemd-resolved
 vim
 wget
 
@@ -45,10 +45,6 @@ wget
 PACKAGES remove
 isc-dhcp-client
 isc-dhcp-common
-libestr0
-libfastjson4
-libisc-export1105
-rsyslog
 
 # These PACKAGES were installed by previous classes.
 # They must be removed with pkg- instead of remove.

--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -5,7 +5,6 @@ ceph
 ceph-base
 ceph-common
 ceph-mgr
-ceph-mgr-diskprediction-local
 ceph-mon
 ceph-osd
 corosync
@@ -21,6 +20,7 @@ pacemaker
 python3-ceph-argparse
 python3-cephfs
 qemu-block-extra
+qemu-system-x86
 qemu-utils
 snmpd
 tuna


### PR DESCRIPTION
In accordance with SEAPATH TSC on Oct 12, 2023, this PR will make build_debian_iso generate seapath installation media based on debian 12.
The branch "debian11" has been created based on current main.