### PR TITLE
Revert "custom vars: customizing disklist"

### DIFF
--- a/srv_fai_config/class/SEAPATH_COMMON.var.defaults
+++ b/srv_fai_config/class/SEAPATH_COMMON.var.defaults
@@ -49,6 +49,3 @@ REMOTEGW=10.0.0.1
 # all: DHCP will be enable for all interface
 # [interface]: DHCP will be enable for the interface. e.g enp1s0
 REMOTEDHCP=no
-
-# You should customize the disk list depending on your hardware.
-#disklist="disk/by-path/pci-0000:c3:00.0-scsi-0:0:0:0 disk/by-path/pci-0000:c3:00.0-scsi-0:0:1:0 "


### PR DESCRIPTION
It does not work: for partition number FAI adds a number to the disk (/dev/sda --> /dev/sda1, /dev/sda2...). This pattern does not work with "by-path" (where we must use -part1, -part2...)

This reverts commit 575d6d8409b67f7bf2a3542b26b423ab35023aae.