### PR TITLE
SEAPATH_HOST: add ntfs-3g to packages list

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -15,6 +15,7 @@ libvirt-clients
 libvirt-daemon
 libvirt-daemon-driver-storage-rbd
 libvirt-daemon-system
+ntfs-3g
 openvswitch-switch
 pacemaker
 python3-ceph-argparse


### PR DESCRIPTION
This will allow the host to be able to read a windows guest disk to retrieve the disk occupation without agent