### PR TITLE
docker-compose.yml: Remove FAI basefile bootstrap

### DIFF
--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -26,7 +26,7 @@ docker-compose -f $wd/docker-compose.yml down
 # Creating the VM
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
 CLASSES="DEBIAN,FAIBASE,FRENCH,BOOKWORM64,SEAPATH_COMMON,SEAPATH_VM,GRUB_EFI,LAST"
-docker-compose -f $wd/docker-compose.yml run --rm -e FAI_BASEFILEURL=https://fai-project.org/download/basefiles/ fai-cd bash -c "\
+docker-compose -f $wd/docker-compose.yml run fai-cd bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/var/cache/apt/pkgcache\.bin|-d \\\"\\\$FAI_ROOT/var/lib/apt/lists|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   fai-diskimage -vu seapath-vm -S10G -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"


### PR DESCRIPTION
FAI's basefile for BOOKWORM64 is some months old right now. Using it triggers a udev upgrade that, with /dev bound into the chroot, change the ownership of /dev/kvm on the build host.

To avoid this, remove FAI basefile bootstrap, FAI will create a fresh basefile without triggering the problematic udev upgrade.

This increase build time by around 1 minute.