### PR TITLE
prevents FAI to upgrade to 6.2 in the NFSROOT

### DIFF
--- a/etc_fai/apt/sources.list
+++ b/etc_fai/apt/sources.list
@@ -5,7 +5,7 @@ deb http://ftp.fr.debian.org/debian-security bookworm-security main contrib non-
 deb http://ftp.fr.debian.org/debian bookworm-backports main contrib non-free
 
 # repository that may contain newer fai packages for bookworm
-deb [arch=amd64] http://fai-project.org/download bookworm koeln
+#deb [arch=amd64] http://fai-project.org/download bookworm koeln
 
 #Elastic
 deb [arch=amd64] https://artifacts.elastic.co/packages/8.x/apt stable main


### PR DESCRIPTION
We include the standard bookworm version of FAI in the docker image (6.0.3), but FAI upgrades the version in the NFSROOT to the one present in the project repository (fai-project.org/download). The project recently upgraded this version to 6.2, giving an inconsistency between the build_debian_iso configuration (qualified for 6.0.3) and the actual used FAI version (6.2).

This commits prevent FAI to upgrade to 6.2 in the NFSROOT.