### PR TITLE
build scripts: make them compatible with docker compose v2

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -3,6 +3,16 @@
 wd=$(dirname $0)
 output_dir=.
 
+# test if "docker compose" works
+docker compose >/dev/null 2>&1
+returncode=$?
+if [ $returncode -eq 0 ]; then
+  COMPOSECMD="docker compose"
+else
+  COMPOSECMD="docker-compose"
+fi
+echo "We are going to use $COMPOSECMD"
+
 rm -f $output_dir/seapath.iso
 # removing the volume in case it exists from a precedent build operation
 docker rm -f fai-setup 2>/dev/null
@@ -15,7 +25,7 @@ set -ex
 # Removing 50-host-classes to prevent DEMO and FAIBASE to be added to the list of classes
 # Adding the Bookworm basefiles to that we deploy a Debian v12 distro
 # Patches /sbin/install_packages (bug in the process of being corrected upstream)
-docker-compose -f $wd/docker-compose.yml run --rm fai-setup bash -c "\
+$COMPOSECMD -f $wd/docker-compose.yml run --rm fai-setup bash -c "\
     echo \"fai-setup -v -e -f \" && \
     fai-setup -v -e -f && \
     echo \"rm -f /ext/srv/fai/config/class/50-host-classes\" && \
@@ -29,27 +39,27 @@ docker-compose -f $wd/docker-compose.yml run --rm fai-setup bash -c "\
     wget -O /ext/srv/fai/config/basefiles/BOOKWORM64.tar.xz https://fai-project.org/download/basefiles/BOOKWORM64.tar.xz"
 
 # Starting the container to add stuff in it
-docker-compose -f $wd/docker-compose.yml up --no-start fai-setup
+$COMPOSECMD -f $wd/docker-compose.yml up --no-start fai-setup
 
 # Adding the SEAPATH workspace
 docker cp $wd/srv_fai_config/. fai-setup:/ext/srv/fai/config/
 
 # Stopping the container after having added stuff in it
-docker-compose -f $wd/docker-compose.yml down
+$COMPOSECMD -f $wd/docker-compose.yml down
 
 # Creating the mirror
 CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,SEAPATH_HOST,SEAPATH_DBG,SEAPATH_KERBEROS"
-docker-compose -f $wd/docker-compose.yml run --rm fai-setup bash -c "\
+$COMPOSECMD -f $wd/docker-compose.yml run --rm fai-setup bash -c "\
     cp /etc/fai/apt/keys/* /etc/apt/trusted.gpg.d/ &&\
     fai-mirror -c $CLASSES /ext/mirror"
 
 # Creating the ISO
-docker-compose -f $wd/docker-compose.yml run --rm fai-cd fai-cd -f -m /ext/mirror /ext/seapath.iso
+$COMPOSECMD -f $wd/docker-compose.yml run --rm fai-cd fai-cd -f -m /ext/mirror /ext/seapath.iso
 
 # Retrieving the ISO from the volume
-docker-compose -f $wd/docker-compose.yml up --no-start fai-setup
+$COMPOSECMD -f $wd/docker-compose.yml up --no-start fai-setup
 docker cp fai-setup:/ext/seapath.iso $output_dir/
-docker-compose -f $wd/docker-compose.yml down
+$COMPOSECMD -f $wd/docker-compose.yml down --remove-orphans
 
 # Removing the volume
 docker volume rm build_debian_iso_ext

--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -3,6 +3,16 @@
 wd=$(dirname $0)
 output_dir=.
 
+# test if "docker compose" works
+docker compose >/dev/null 2>&1
+returncode=$?
+if [ $returncode -eq 0 ]; then
+  COMPOSECMD="docker compose"
+else
+  COMPOSECMD="docker-compose"
+fi
+echo "We are going to use $COMPOSECMD"
+
 rm -f $output_dir/seapath-vm.qcow2
 # removing the volume in case it exists from a precedent build operation
 docker rm -f fai-setup 2>/dev/null
@@ -11,31 +21,31 @@ docker volume rm build_debian_iso_ext 2>/dev/null
 set -ex
 
 # Create the default config space
-docker-compose -f $wd/docker-compose.yml run --rm fai-setup \
+$COMPOSECMD -f $wd/docker-compose.yml run --rm fai-setup \
     fai-mk-configspace
 
 # Starting the container to add seapath stuff in the config space
-docker-compose -f $wd/docker-compose.yml up --no-start fai-setup
+$COMPOSECMD -f $wd/docker-compose.yml up --no-start fai-setup
 
 # Adding the SEAPATH config
 docker cp $wd/srv_fai_config/. fai-setup:ext/srv/fai/config/
 
 # Stopping the container after having added stuff in it
-docker-compose -f $wd/docker-compose.yml down
+$COMPOSECMD -f $wd/docker-compose.yml down
 
 # Creating the VM
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
 CLASSES="DEBIAN,FAIBASE,FRENCH,BOOKWORM64,SEAPATH_COMMON,SEAPATH_VM,GRUB_EFI,LAST"
-docker-compose -f $wd/docker-compose.yml run fai-cd bash -c "\
+$COMPOSECMD -f $wd/docker-compose.yml run fai-cd bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/var/cache/apt/pkgcache\.bin|-d \\\"\\\$FAI_ROOT/var/lib/apt/lists|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
   fai-diskimage -vu seapath-vm -S10G -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"
 
 # Retrieving the ISO from the volume
-docker-compose -f $wd/docker-compose.yml up --no-start fai-setup
+$COMPOSECMD -f $wd/docker-compose.yml up --no-start fai-setup
 docker cp fai-setup:/ext/seapath-vm.qcow2 $output_dir/
-docker-compose -f $wd/docker-compose.yml down
+$COMPOSECMD -f $wd/docker-compose.yml down --remove-orphans
 
 # Removing the volume
 docker volume rm build_debian_iso_ext


### PR DESCRIPTION
docker compose v2 integrate with docker cli, in that case we must call compose with "docker compose" instead of "docker-compose".
This commits looks for "docker compose" and falls back to "docker-compose" if needed