### PR TITLE
github/workflows: add workflow_call to shellcheck-weekly

### DIFF
--- a/.github/workflows/shellcheck-weekly.yml
+++ b/.github/workflows/shellcheck-weekly.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '30 22 * * 6'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   call-workflow:


### PR DESCRIPTION
This will allow us to trigger the shellcheck-weekly workflow from other workflows. This is needed to run shellcheck-weekly manually.