### PR TITLE
Replace direct Real-Time tuning with Tuned.

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -28,5 +28,5 @@ qemu-block-extra
 qemu-system-x86
 qemu-utils
 snmpd
-tuna
+tuned
 virtinst

--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -16,6 +16,7 @@ libvirt-clients
 libvirt-daemon
 libvirt-daemon-driver-storage-rbd
 libvirt-daemon-system
+linux-perf
 nginx
 ntfs-3g
 openvswitch-switch


### PR DESCRIPTION
We have a lot of code for the purpose of tuning the host machines for real-time Latency.
The TuneD is a system tuning service can simplify the code and improve results.
Please see PR in the  seapath/ansible repo:
https://github.com/seapath/ansible/pull/444


