### PR TITLE
build_qcow2: Fixes wrong path in new FAI version

### DIFF
--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -37,7 +37,7 @@ $COMPOSECMD -f $wd/docker-compose.yml down
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
 CLASSES="DEBIAN,FAIBASE,FRENCH,BOOKWORM64,SEAPATH_COMMON,SEAPATH_VM,GRUB_EFI,LAST"
 $COMPOSECMD -f $wd/docker-compose.yml run fai-cd bash -c "\
-  sed -i -e \"s|-f \\\"\\\$FAI_ROOT/var/cache/apt/pkgcache\.bin|-d \\\"\\\$FAI_ROOT/var/lib/apt/lists|\" /sbin/install_packages && \
+  sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
   fai-diskimage -vu seapath-vm -S10G -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"


### PR DESCRIPTION
solves #93 