### PR TITLE
changes in partitionning for HOST and RAID flavors

### DIFF
--- a/srv_fai_config/disk_config/SEAPATH_HOST
+++ b/srv_fai_config/disk_config/SEAPATH_HOST
@@ -5,7 +5,8 @@
 disk_config disk1 disklabel:gpt fstabkey:uuid align-at:1M
 
 primary /boot/efi  512M  vfat    rw
-primary -          100G	 -       -
+primary -          50G	 -       -
+primary -          2G	 -       -
 
 disk_config lvm
 
@@ -13,3 +14,6 @@ vg vg1  disk1.2
 vg1-root    /          15G      ext4    noatime,rw
 vg1-varlog  /var/log    5G      ext4    noatime,rw
 vg1-swap    swap      500M      swap    sw
+
+vg vg_ceph  disk1.3
+vg_ceph-lv_ceph -           1G   -       -

--- a/srv_fai_config/disk_config/SEAPATH_RAID
+++ b/srv_fai_config/disk_config/SEAPATH_RAID
@@ -14,7 +14,7 @@ disk_config lvm
 vg vg1      disk1.2,disk2.2
 vg1-root        /            20G   ext4    noatime,rw  lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 vg1-swap        swap          2G   swap    sw          lvcreateopts="-m 1 --type raid1 --nosync"
-vg1-log         /var/log      5G   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
+vg1-varlog         /var/log      5G   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 
 vg vg_ceph  disk1.3,disk2.3
 vg_ceph-lv_ceph -           200G   -       -           lvcreateopts="-m 1 --type raid1 --nosync"

--- a/srv_fai_config/disk_config/SEAPATH_RAID
+++ b/srv_fai_config/disk_config/SEAPATH_RAID
@@ -2,19 +2,19 @@
 
 disk_config disk1 disklabel:gpt fstabkey:uuid align-at:1M
 primary    /boot/efi   500M  vfat  errors=remount-ro,nofail
-primary    -            40G  -     -
-primary    -           300G  -     -
+primary    -            50G  -     -
+primary    -             2G  -     -
 
 disk_config disk2 disklabel:gpt fstabkey:uuid align-at:1M
 primary    /boot/efi2  500M  vfat  errors=remount-ro,nofail
-primary    -            40G  -     -
-primary    -           300G  -     -
+primary    -            50G  -     -
+primary    -             2G  -     -
 
 disk_config lvm
 vg vg1      disk1.2,disk2.2
 vg1-root        /            20G   ext4    noatime,rw  lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 vg1-swap        swap          2G   swap    sw          lvcreateopts="-m 1 --type raid1 --nosync"
-vg1-varlog         /var/log      5G   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
+vg1-varlog      /var/log      5G   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 
 vg vg_ceph  disk1.3,disk2.3
-vg_ceph-lv_ceph -           200G   -       -           lvcreateopts="-m 1 --type raid1 --nosync"
+vg_ceph-lv_ceph -             1G   -       -           lvcreateopts="-m 1 --type raid1 --nosync"

--- a/srv_fai_config/disk_config/SEAPATH_RAID_DEMO
+++ b/srv_fai_config/disk_config/SEAPATH_RAID_DEMO
@@ -14,7 +14,7 @@ disk_config lvm
 vg vg1      disk1.2,disk2.2
 vg1-root        /          3800M   ext4    noatime,rw  lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 vg1-swap        swap        100M   swap    sw          lvcreateopts="-m 1 --type raid1 --nosync"
-vg1-log         /var/log    100M   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
+vg1-varlog         /var/log    100M   ext4    defaults    lvcreateopts="-m 1 --type raid1 --nosync" createopts="-I 256"
 
 vg vg_ceph  disk1.3,disk2.3
 vg_ceph-lv_ceph -           500M   -       -           lvcreateopts="-m 1 --type raid1 --nosync"


### PR DESCRIPTION
disk_config: /var/log LV renamed from vg1-log to vg1-varlog

This is to have the same LV name for all disk configurations

----
partitioning: make initial ceph VG and LV very small

There is an ansible playbook to increase those to the required sizes to be defined in the inventory