### PR TITLE
SEAPATH_COCKPIT: add package

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_COCKPIT
+++ b/srv_fai_config/package_config/SEAPATH_COCKPIT
@@ -1,3 +1,4 @@
 PACKAGES install-norec
 cockpit
 cockpit-machines
+cockpit-packagekit


### PR DESCRIPTION
Add the cockpit PackageKit plugin used to install Debian updates.