### PR TITLE
SEAPATH_HOST: add firmware-misc-nonfree rec packages to package_config

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -9,7 +9,10 @@ ceph-mon
 ceph-osd
 corosync
 crmsh
+firmware-amd-graphics
 firmware-misc-nonfree
+firmware-linux-nonfree
+firmware-linux-free
 gunicorn
 ipmitool
 libcephfs2


### PR DESCRIPTION
PR https://github.com/seapath/build_debian_iso/pull/99 is incomplete since for all installed packages in the package_config list, we do not install recommend packages.
So we need to explicitely add the recommended packages in the package_config list.