### PR TITLE
.github/workflows: restrict permissions

### DIFF
--- a/.github/workflows/shellcheck-weekly.yml
+++ b/.github/workflows/shellcheck-weekly.yml
@@ -12,6 +12,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  checks: write
+
 jobs:
   call-workflow:
     uses: ./.github/workflows/shellcheck.yml

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,9 @@ on:
     types: [opened, reopened, synchronize]
     branches: [main]
 
+permissions:
+  checks: write
+
 jobs:
   shellcheck:
     name: Shellcheck


### PR DESCRIPTION
Restrict permissions of the CI workflows:
fails
- `checks: write` allows validating the check.