### PR TITLE
SEAPATH_HOST: add intel-cmt-cat and msr-tools to packages list

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_DBG
+++ b/srv_fai_config/package_config/SEAPATH_DBG
@@ -1,13 +1,18 @@
 PACKAGES install-norec
+console-data
+ethtool
 filebeat
 htop
 iotop
 iperf
 iperf3
+linux-cpupower
 metricbeat
 nmon
 rt-tests
+schedtool
 screen
 stress-ng
 sysfsutils
 tcpdump
+tmux

--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -14,6 +14,7 @@ firmware-misc-nonfree
 firmware-linux-nonfree
 firmware-linux-free
 gunicorn
+intel-cmt-cat
 ipmitool
 libcephfs2
 libvirt-clients
@@ -21,6 +22,7 @@ libvirt-daemon
 libvirt-daemon-driver-storage-rbd
 libvirt-daemon-system
 linux-perf
+msr-tools
 nginx
 ntfs-3g
 openvswitch-switch


### PR DESCRIPTION
Added packages for realtime optimizations that I'd like to have included in the official image in SEAPATH_HOST.

Furthermore added packages in SEAPATH_DBG for more convenience.