### PR TITLE
Add the USERCUSTOMIZATION class and allow User-defined classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.iso
-SEAPATH_COMMON.var
+usercustomization/
+build_tmp/
 grub.cfg

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ The possibles flags to create a grub menu item are:
 
 If you want an "english, no debug, no raid, no cockpit, no kerberos, standalone" installation, then you need to uncheck everything, which will result in a fake "noflag" grub menu item being added. This is normal.
 
+** User-defined classes **
+The user can manage his own classes by:
+- adding the class in the user_classes.conf file
+- dealing with a numbered script in usercustomization/class/ folder (for example usercustomization/class/99-custom, chmod 755) to use the class (see srv_fai_config/class/99-seapath script for reference)
+- adding all the files related to the classes in the usercustomization hierarchy (for example usercustomization/package_config/USERCLASS1)
+
+
 ## Build a Virtual Machine image
 
 To build a basic VM for the SEAPATH project, simply launch the script `build_qcow2.sh` from the directory where you want the .qcow2 file to be stored (the build host must use UEFI).

--- a/README.md
+++ b/README.md
@@ -16,8 +16,17 @@ However please checkout the Customization section first. There are some things t
 
 ## Customization
 Some customization you will want to make before building.
-First, copy the srv_fai_config/class/SEAPATH_COMMON.var.defaults file to srv_fai_config/class/SEAPATH_COMMON.var
-You will make your changes in this new file.
+For that you can add all the files you need in the build_debian_iso/usercustomization hierarchy, using the USERCUSTOMIZATION class name:
+- add your variables in the build_debian_iso/usercustomization/class/USERCUSTOMIZATION.var file
+- add your debconf parameters to build_debian_iso/usercustomization/debconf/USERCUSTOMIZATION file
+- add your disk config to build_debian_iso/usercustomization/disk_config/USERCUSTOMIZATION file
+- add your files to build_debian_iso/usercustomization/files/ hierarchy using USERCUSTOMIZATION as the class name (for example build_debian_iso/usercustomization/files/etc/motd/USERCUSTOMIZATION)
+- add your hooks to build_debian_iso/usercustomization/hooks/ using USERCUSTOMIZATION as the class name (for example build_debian_iso/usercustomization/hooks/install.USERCUSTOMIZATION)
+- add your package_config to build_debian_iso/usercustomization/package_config/USERCUSTOMIZATION file
+- add your scripts to build_debian_iso/usercustomization/scripts using USERCUSTOMIZATION as the class name (for example build_debian_iso/usercustomization/scripts/USERCUSTOMIZATION/88-myscript)
+
+Both folders "build_debian_iso/usercustomization and build_debian_iso/srv_fai_config will be merged into build_debian_iso/build_tmp when building).
+
 
 ### Mandatory
 **change the authorized_keys files (user and root) with your own**

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -24,6 +24,10 @@ if [ ! -f "$wd"/etc_fai/grub.cfg ]; then
   cp "$wd"/etc_fai/grub_base.cfg "$wd"/etc_fai/grub.cfg
 fi
 
+rm -rf "$wd"/build_tmp/*
+cp -r "$wd/srv_fai_config/"* "$wd/build_tmp"
+cp -r "$wd/usercustomization/"* "$wd/build_tmp"
+
 finalClasses="SEAPATH_CLUSTER,SEAPATH_DBG,SEAPATH_KERBEROS,SEAPATH_COCKPIT,"
 
 if [ "$1" == "--custom" ]; then
@@ -148,13 +152,13 @@ $COMPOSECMD -f "$wd"/docker-compose.yml run --rm fai-setup bash -c "\
 $COMPOSECMD -f "$wd"/docker-compose.yml up --no-start fai-setup
 
 # Adding the SEAPATH workspace
-docker cp "$wd"/srv_fai_config/. fai-setup:/ext/srv/fai/config/
+docker cp "$wd"/build_tmp/. fai-setup:/ext/srv/fai/config/
 
 # Stopping the container after having added stuff in it
 $COMPOSECMD -f "$wd"/docker-compose.yml down
 
 # Creating the mirror
-CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,${finalClasses}LAST"
+CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,${finalClasses}USERCUSTOMIZATION,LAST"
 $COMPOSECMD -f "$wd"/docker-compose.yml run --rm fai-setup bash -c "\
     cp /etc/fai/apt/keys/* /etc/apt/trusted.gpg.d/ &&\
     fai-mirror -c $CLASSES /ext/mirror"
@@ -169,3 +173,4 @@ $COMPOSECMD -f "$wd"/docker-compose.yml down --remove-orphans
 
 # Removing the volume
 docker volume rm build_debian_iso_ext
+rm -rf "$wd"/build_tmp/*

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -157,8 +157,11 @@ docker cp "$wd"/build_tmp/. fai-setup:/ext/srv/fai/config/
 # Stopping the container after having added stuff in it
 $COMPOSECMD -f "$wd"/docker-compose.yml down
 
+# List user defined Classes
+userClasses=$(grep -Ev "^#|^$" "$wd"/user_classes.conf | tr '\n' ',' | sed -e "s/,$//")
+
 # Creating the mirror
-CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,${finalClasses}USERCUSTOMIZATION,LAST"
+CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,${finalClasses}USERCUSTOMIZATION,${userClasses},LAST"
 $COMPOSECMD -f "$wd"/docker-compose.yml run --rm fai-setup bash -c "\
     cp /etc/fai/apt/keys/* /etc/apt/trusted.gpg.d/ &&\
     fai-mirror -c $CLASSES /ext/mirror"

--- a/srv_fai_config/class/98-seapath
+++ b/srv_fai_config/class/98-seapath
@@ -14,4 +14,6 @@ echo DEBIAN FAIBASE BOOKWORM64 SEAPATH_COMMON SEAPATH_HOST
 [ "$flag_kerberos" ] && echo "SEAPATH_KERBEROS"
 [ "$flag_cockpit" ] && echo "SEAPATH_COCKPIT"
 
+echo "USERCUSTOMIZATION"
+
 exit 0

--- a/srv_fai_config/class/98-seapath
+++ b/srv_fai_config/class/98-seapath
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # do not use this if a menu will be presented
 [ "$flag_menu" ] && exit 0

--- a/srv_fai_config/class/SEAPATH_COMMON.var
+++ b/srv_fai_config/class/SEAPATH_COMMON.var
@@ -1,4 +1,4 @@
-# default values for installation. You can override them in your *.var files
+# default values for installation. You can override them in your usercustomization/class/USERCUSTOMIZATION.var file
 
 HOSTNAME=debian
 
@@ -31,8 +31,8 @@ USERPW='$y$j9T$s.szNr.QzTLk8h5qMYDpo0$YMaC8.04FilI/1AguyofvbV4FH1me6Nc7SHP4hyefZ
 usernameansible=ansible
 
 myrootkey='ssh-rsa XXX'
-myuserkey='ssh-rsa XXX'
-ansiblekey='ssh-rsa XXX'
+myuserkey='ssh-rsa YYY'
+ansiblekey='ssh-rsa ZZZ'
 
 #APTPROXY=http://proxy:3128
 apt_cdn=http://ftp.fr.debian.org

--- a/user_classes.conf
+++ b/user_classes.conf
@@ -1,0 +1,4 @@
+# list user defined classes, one class per line
+# exemple : 
+# USERCLASS1
+# USERCLASS2


### PR DESCRIPTION
Add the USERCUSTOMIZATION class to facilitate user configuration

This commits splits the base hierarchy into 3:
- srv_fai_config is still the default SEAPATH configuration
- usercustomization is the same hierarchy but git will not track it, and the user can put custom files in it
- build_tmp is a temporary folder where the installer will merge srv_fai_config and userconfiguration just before merging

srv_fai_config also includes now the new USERCUSTOMIZATION class, so that the files in the usercustomization/ folder can implement this class and override/add any setting.

----
Allows userdefined classes

With this commit the user can add his own classes by:
- adding the class in the user_classes.conf file
- dealing with a numbered script in usercustomization/class/ folder (for example usercustomization/class/99-custom, chmod 755) to use the class
- adding all the files related to the classes in the usercustomization hierarchy
