### PR TITLE
SEAPATH_COMMON: add netplan

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_COMMON
+++ b/srv_fai_config/package_config/SEAPATH_COMMON
@@ -26,6 +26,7 @@ lm-sensors
 lsb-release
 lvm2
 net-tools
+netplan.io
 openssh-server
 ovmf
 parted

--- a/srv_fai_config/scripts/SEAPATH_COMMON/40-networking
+++ b/srv_fai_config/scripts/SEAPATH_COMMON/40-networking
@@ -1,6 +1,8 @@
 #!/bin/bash
 error=0; trap 'error=$(($?>$error?$?:$error))' ERR # save maximum error code
 $ROOTCMD rm -f /etc/network/interfaces
+$ROOTCMD rm -rf /etc/netplan
+$ROOTCMD mkdir /etc/netplan
 $ROOTCMD systemctl enable --now systemd-networkd
 $ROOTCMD systemctl disable systemd-networkd-wait-online.service
 $ROOTCMD mkdir -p /root/.ssh


### PR DESCRIPTION
Netplan will now be used as a high level network configuration tool for SEAPATH.