### PR TITLE
build_iso.sh: add SEAPATH_HOST to list of classes

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -166,7 +166,7 @@ $COMPOSECMD -f "$wd"/docker-compose.yml down
 userClasses=$(grep -Ev "^#|^$" "$wd"/user_classes.conf | tr '\n' ',' | sed -e "s/,$//")
 
 # Creating the mirror
-CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,${finalClasses}USERCUSTOMIZATION,${userClasses},LAST"
+CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,SEAPATH_HOST,${finalClasses}USERCUSTOMIZATION,${userClasses},LAST"
 $COMPOSECMD -f "$wd"/docker-compose.yml run --rm fai-setup bash -c "\
     cp /etc/fai/apt/keys/* /etc/apt/trusted.gpg.d/ &&\
     fai-mirror -c $CLASSES /ext/mirror"


### PR DESCRIPTION
This one was forgotten when moving to whiptail.