### PR TITLE
kernel version: use the debian stable version (6.6)

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_COMMON
+++ b/srv_fai_config/package_config/SEAPATH_COMMON
@@ -20,7 +20,7 @@ iptables-persistent
 irqbalance
 jq
 lbzip2
-linux-image-rt-amd64/bookworm-backports
+linux-image-rt-amd64
 linuxptp
 lm-sensors
 lsb-release


### PR DESCRIPTION
We do not need to use the backported version anymore. 6.6 contains all the features we need + it's LTS.