### PR TITLE
build_qcow2: allows the VM disk size to be customized

### DIFF
--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -3,6 +3,50 @@
 wd=$(dirname "$0")
 output_dir=.
 
+DISKSIZE="10G"
+if ! OPTIONS=$(getopt -o hvs: --long help,version,vmdisksize: -- "$@"); then
+    echo "Usage: $0 [-h|--help] [-v|--version] [-s|--vmdisksize SIZE]" >&2
+    exit 1
+fi
+eval set -- "$OPTIONS"
+while true; do
+    case "$1" in
+        -h|--help)
+            echo "Usage: $0 [options]"
+            echo "Options:"
+            echo "  -h, --help           Display this help message"
+            echo "  -v, --version        Display version information"
+            echo "  -s, --vmdisksize SIZE Specify the VM disk size (required argument)"
+            exit 0
+            ;;
+        -v|--version)
+            echo "Version 1.0"
+            exit 0
+            ;;
+        -s|--vmdisksize)
+            if [ -n "$2" ] && [[ $2 != -* ]]; then
+                echo "VM disk size specified: $2"
+                DISKSIZE=$2
+                shift 2
+            else
+                echo "Error: The -s|--vmdisksize option requires an argument." >&2
+                exit 1
+            fi
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+if [ $# -gt 0 ]; then
+    echo "Additional arguments: $*"
+fi
+
 # test if "docker compose" works
 docker compose >/dev/null 2>&1
 returncode=$?
@@ -44,7 +88,7 @@ $COMPOSECMD -f "$wd"/docker-compose.yml run fai-cd bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
-  fai-diskimage -vu seapath-vm -S10G -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"
+  fai-diskimage -vu seapath-vm -S${DISKSIZE} -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"
 
 # Retrieving the ISO from the volume
 $COMPOSECMD -f "$wd"/docker-compose.yml up --no-start fai-setup


### PR DESCRIPTION
The USERCUSTOMIZATION feature allows the user to configure its own partitioning for the SEAPATH VM, however, the total disk size is hardcoded in the build_qcow2.sh script.
This commit introduces a optional parameter ro specify the target total disk size for a VM (-s / --vmdisksize).
Since this script is starting to have parameters, we also add an "--help" and "--version" parameter to help a user figure out the parameters.