### PR TITLE
SEAPATH_COMMON: add libxml2-utils

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -12,6 +12,7 @@ libvirt-clients
 libvirt-daemon
 libvirt-daemon-driver-storage-rbd
 libvirt-daemon-system
+libxml2-utils
 linux-perf
 msr-tools
 nginx


### PR DESCRIPTION
This package contains xmllint, a command line XML tool. It is used to validate the xml file and print the error if the file is not valid.

xmllinit is used by libvirt to add more information if the xml file is not valid. It is also used by the resource-agents VirtualDomain during the configuration saving.