### PR TITLE
snmp: add libsnmp-extension-passpersist-perl

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -8,6 +8,7 @@ firmware-linux-free
 gunicorn
 intel-cmt-cat
 ipmitool
+libsnmp-extension-passpersist-perl
 libvirt-clients
 libvirt-daemon
 libvirt-daemon-driver-storage-rbd


### PR DESCRIPTION
needed for the snmp agent to work