### PR TITLE
SEAPATH_HOST: adds python3-pip

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -18,6 +18,7 @@ nginx
 ntfs-3g
 openvswitch-switch
 python3-flaskext.wtf
+python3-pip
 python3-xmltodict
 qemu-block-extra
 qemu-system-x86


### PR DESCRIPTION
Needed for the new way of installing python packages (vm_manager and setup_ovs)