### PR TITLE
docker-compose: add selinux support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
     volumes:
       - ext:/ext
-      - ./etc_fai:/etc/fai:ro
+      - ./etc_fai:/etc/fai:ro,Z
     cap_add:
       - SYS_ADMIN
     security_opt:
@@ -19,9 +19,9 @@ services:
       context: .
     volumes:
       - ext:/ext
-      - ./etc_fai:/etc/fai:ro
+      - ./etc_fai:/etc/fai:ro,Z
       - /dev:/dev
-      - /tmp/fai:/var/log/fai
+      - /tmp/fai:/var/log/fai:Z
     privileged: true
     container_name: fai-cd
 volumes:


### PR DESCRIPTION
This commit adds the Z option to the volumes in the docker-compose file to support selinux. This is necessary to run the container on a system with selinux enabled.