### PR TITLE
build_iso.sh: disable raid by default

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -65,7 +65,7 @@ if [ "$1" == "--custom" ]; then
   done
 
   addFlagCombination() {
-    listFlags=("french" "FRENCH keyboard rather than english" "OFF" "german" "GERMAN keyboard rather than english" "OFF" "dbg" "DEBUG packages" "OFF" "raid" "lvm RAID" "ON" "cockpit" "COCKPIT packages" "OFF" "kerberos" "KERBEROS packages" "OFF" "cluster" "CLUSTER rather than standalone" "ON")
+    listFlags=("french" "FRENCH keyboard rather than english" "OFF" "german" "GERMAN keyboard rather than english" "OFF" "dbg" "DEBUG packages" "OFF" "raid" "lvm RAID" "OFF" "cockpit" "COCKPIT packages" "OFF" "kerberos" "KERBEROS packages" "OFF" "cluster" "CLUSTER rather than standalone" "ON")
     arrVar=()
     if CHOICES=$(whiptail --separate-output --checklist "Choose flags combination to add to grub" 18 60 7 "${listFlags[@]}" 3>&1 1>&2 2>&3); then
       # code 0

--- a/etc_fai/grub_base.cfg
+++ b/etc_fai/grub_base.cfg
@@ -13,11 +13,11 @@ set menu_color_highlight=black/yellow
 
 menuentry "SEAPATH INSTALLER      |     _VERSIONSTRING_     |" --unrestricted { set timeout=20 }
 ## BEGIN CUSTOM MENU ITEMS
-set default="  SEAPATH installation - Cluster mode with LVMRAID, English, no kerberos, no debug tools"
+set default="  SEAPATH installation - Cluster mode, English, no lvmraid, no kerberos, no debug tools"
 set timeout=5
-menuentry "  SEAPATH installation - Cluster mode with LVMRAID, English, no kerberos, no debug tools" {
+menuentry "  SEAPATH installation - Cluster mode, English, no lvmraid, no kerberos, no debug tools" {
     search --set=root --file /FAI-CD
-    linux   /boot/vmlinuz FAI_FLAGS="cluster,raid,verbose,sshd,createvt,reboot" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1
+    linux   /boot/vmlinuz FAI_FLAGS="cluster,verbose,sshd,createvt,reboot" FAI_ACTION=install FAI_CONFIG_SRC=file:///var/lib/fai/config rd.live.image root=live:CDLABEL=FAI_CD ipv6.disable=1 console=tty1
     initrd  /boot/initrd.img
 }
 ## END CUSTOM MENU ITEMS


### PR DESCRIPTION
Newcomers will not want to use raid on SEAPATH.
Advanced user will use the '--custom' flag and add it manually.