### PR TITLE
fai-setup: use privileged for fai-setup container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,7 @@ services:
     volumes:
       - ext:/ext
       - ./etc_fai:/etc/fai:ro,Z
-    cap_add:
-      - SYS_ADMIN
-    security_opt:
-      - seccomp:unconfined
-      - apparmor:unconfined
+    privileged: true
     container_name: fai-setup
   fai-cd:
     image: fai


### PR DESCRIPTION
SYS_ADMIN capability and the security_opt are not enough to run the fai-setup container on a system using SELinux like Fedora.

Fix #132 