### PR TITLE
generate_seapath_image: add support of image metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ ext/*
 etc_fai/grub.cfg
 user_classes.conf
 .vscode/
+__pycache__/

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -4,78 +4,10 @@ version="2.1"
 
 set -e
 
-function generate_seapath_metadata() {
-    OUTPUT=$OUTPUT output_dir=$output_dir role=$ROLE python3 - << END
-from pathlib import Path
-import xml.etree.ElementTree as ET
-import hashlib
-from os import environ
-
-working_dir = environ.get('output_dir', '')
-bmap_file = f'{environ.get('OUTPUT', '')}.bmap'
-
-role = environ.get('role', '')
-role = role.lower()
-
-if 'standalone' in role:
-    setup = 'Standalone'
-else:
-    setup = 'Cluster'
-
-# image_deploy_dir = Path(d.getVar('IMGDEPLOYDIR'))
-# bmap_image_name = d.getVar('IMAGE_LINK_NAME')
-bmap_path = working_dir + f'/{bmap_file}'
-print(bmap_path)
-# if not bmap_path.exists():
-#    raise 'Missing bmap file: %s' % bmap_path
-
-bmap_tree = ET.parse(str(bmap_path))
-root = bmap_tree.getroot()
-
-for tag, value in [
-    ('ImageName',        'SEAPATH Debian'),
-    ('ImageVersion',     '1.2.0'),
-    ('ImageDescription', 'A production image for SEAPATH'),
-    ('ImageSetup', setup),
-    ('ImageFlavor', 'Debian'),
-]:
-    node = ET.SubElement(root, tag)
-    node.text = f' {value} '
-    node.tail = '\n'
-
-
-# bmap-tools check for bmap file interity with a checksum computed
-# image build. As we modify the file we need to update the checksum
-# of the file:
-#   1. Reset the checksum to 0
-#   2. Compute the checksum of the file
-#   3. Replace with the new computed checksum
-bmap_file_checksum = root.find('BmapFileChecksum')
-len_bmap_file_checksum = len(str.strip(bmap_file_checksum.text))
-
-bmap_file_checksum.text = '0' * len_bmap_file_checksum
-root.tail = '\n'
-
-bmap_tree.write(str(bmap_path), encoding='utf-8', xml_declaration=False)
-
-checksum_type=root.find('ChecksumType')
-checksum_type_value = str.strip(checksum_type.text)
-
-block_size=root.find('BlockSize')
-block_size_value = int(str.strip(block_size.text))
-hash_obj = hashlib.new(str.strip(checksum_type.text))
-
-with open(bmap_path, 'rb') as file:
-    while chunk := file.read(block_size_value):
-        hash_obj.update(chunk)
-
-bmap_file_updated_hash = hash_obj.hexdigest()
-bmap_file_checksum.text = bmap_file_updated_hash
-
-bmap_tree.write(str(bmap_path), encoding='utf-8', xml_declaration=False)
-
-END
-
+function generate_seapath_metadata {
+    OUTPUT=$OUTPUT output_dir=$output_dir role=$ROLE \
+        SEAPATH_VERSION=$SEAPATH_VERSION \
+        python3 "$wd/generate_seapath_metadata.py"
 }
 
 print_usage() {
@@ -115,7 +47,7 @@ if [ "${1,,}" == "-h" ] || [ "${1,,}" == "--help" ]; then
 fi
 
 wd=$(dirname "$0")
-SEAPATH_VERSION="1.2.0"
+SEAPATH_VERSION=$(git -C "$wd" describe --tags --dirty 2>/dev/null || echo "unknown")
 output_dir=.
 ext_dir=$wd/ext
 fai_config_dir=$ext_dir/srv/fai/config

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -4,6 +4,80 @@ version="2.1"
 
 set -e
 
+function generate_seapath_metadata() {
+    OUTPUT=$OUTPUT output_dir=$output_dir role=$ROLE python3 - << END
+from pathlib import Path
+import xml.etree.ElementTree as ET
+import hashlib
+from os import environ
+
+working_dir = environ.get('output_dir', '')
+bmap_file = f'{environ.get('OUTPUT', '')}.bmap'
+
+role = environ.get('role', '')
+role = role.lower()
+
+if 'standalone' in role:
+    setup = 'Standalone'
+else:
+    setup = 'Cluster'
+
+# image_deploy_dir = Path(d.getVar('IMGDEPLOYDIR'))
+# bmap_image_name = d.getVar('IMAGE_LINK_NAME')
+bmap_path = working_dir + f'/{bmap_file}'
+print(bmap_path)
+# if not bmap_path.exists():
+#    raise 'Missing bmap file: %s' % bmap_path
+
+bmap_tree = ET.parse(str(bmap_path))
+root = bmap_tree.getroot()
+
+for tag, value in [
+    ('ImageName',        'SEAPATH Debian'),
+    ('ImageVersion',     '1.2.0'),
+    ('ImageDescription', 'A production image for SEAPATH'),
+    ('ImageSetup', setup),
+    ('ImageFlavor', 'Debian'),
+]:
+    node = ET.SubElement(root, tag)
+    node.text = f' {value} '
+    node.tail = '\n'
+
+
+# bmap-tools check for bmap file interity with a checksum computed
+# image build. As we modify the file we need to update the checksum
+# of the file:
+#   1. Reset the checksum to 0
+#   2. Compute the checksum of the file
+#   3. Replace with the new computed checksum
+bmap_file_checksum = root.find('BmapFileChecksum')
+len_bmap_file_checksum = len(str.strip(bmap_file_checksum.text))
+
+bmap_file_checksum.text = '0' * len_bmap_file_checksum
+root.tail = '\n'
+
+bmap_tree.write(str(bmap_path), encoding='utf-8', xml_declaration=False)
+
+checksum_type=root.find('ChecksumType')
+checksum_type_value = str.strip(checksum_type.text)
+
+block_size=root.find('BlockSize')
+block_size_value = int(str.strip(block_size.text))
+hash_obj = hashlib.new(str.strip(checksum_type.text))
+
+with open(bmap_path, 'rb') as file:
+    while chunk := file.read(block_size_value):
+        hash_obj.update(chunk)
+
+bmap_file_updated_hash = hash_obj.hexdigest()
+bmap_file_checksum.text = bmap_file_updated_hash
+
+bmap_tree.write(str(bmap_path), encoding='utf-8', xml_declaration=False)
+
+END
+
+}
+
 print_usage() {
     echo 'This script generates SEAPATH images base on Debian to be used in the "seapath-installer".'
     echo ""
@@ -41,6 +115,7 @@ if [ "${1,,}" == "-h" ] || [ "${1,,}" == "--help" ]; then
 fi
 
 wd=$(dirname "$0")
+SEAPATH_VERSION="1.2.0"
 output_dir=.
 ext_dir=$wd/ext
 fai_config_dir=$ext_dir/srv/fai/config
@@ -297,6 +372,7 @@ if command -v bmaptool >/dev/null ; then
     else
         gzip "$output_dir/${OUTPUT}"
     fi
+    generate_seapath_metadata
 fi
 
 echo "SEAPATH image generation completed."

--- a/generate_seapath_metadata.py
+++ b/generate_seapath_metadata.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import xml.etree.ElementTree as ET
+import hashlib
+from os import environ
+
+working_dir = environ.get("output_dir", "")
+bmap_file = f"{environ.get('OUTPUT', '')}.bmap"
+
+role = environ.get("role", "")
+role = role.lower()
+
+if "standalone" in role:
+    setup = "Standalone"
+else:
+    setup = "Cluster"
+
+bmap_path = Path(working_dir) / bmap_file
+if not bmap_path.exists():
+    raise FileNotFoundError("Missing bmap file: %s" % bmap_path)
+
+bmap_tree = ET.parse(str(bmap_path))
+root = bmap_tree.getroot()
+
+seapath_version = environ.get("SEAPATH_VERSION", "unknown")
+
+for tag, value in [
+    ("ImageName", "SEAPATH Debian"),
+    ("ImageVersion", seapath_version),
+    ("ImageDescription", "A production image for SEAPATH"),
+    ("ImageSetup", setup),
+    ("ImageFlavor", "Debian"),
+]:
+    node = ET.SubElement(root, tag)
+    node.text = f" {value} "
+    node.tail = "\n"
+
+bmap_file_checksum = root.find("BmapFileChecksum")
+len_bmap_file_checksum = len(str.strip(bmap_file_checksum.text))
+
+bmap_file_checksum.text = "0" * len_bmap_file_checksum
+root.tail = "\n"
+
+bmap_tree.write(str(bmap_path), encoding="utf-8", xml_declaration=False)
+
+checksum_type = root.find("ChecksumType")
+
+block_size = root.find("BlockSize")
+block_size_value = int(str.strip(block_size.text))
+hash_obj = hashlib.new(str.strip(checksum_type.text))
+
+with open(bmap_path, "rb") as file:
+    while chunk := file.read(block_size_value):
+        hash_obj.update(chunk)
+
+bmap_file_updated_hash = hash_obj.hexdigest()
+bmap_file_checksum.text = bmap_file_updated_hash
+
+bmap_tree.write(str(bmap_path), encoding="utf-8", xml_declaration=False)


### PR DESCRIPTION
Currently, there are no ways to identify, from a SEAPATH Debian raw image what the image is (version, flavor, type, etc). Because of that, the SEAPATH installer cannot automatically identify the image, and the flavor associated.
To fix this, add generated image metadata (name, flavor, version, description), in the bmap file associated.