### PR TITLE
SBOM for container images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /*.bmap
 /*.raw
 /*.qcow2
-/sbom.*
+/sbom
 
 usercustomization/class/*
 usercustomization/debconf/*

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -281,8 +281,8 @@ if [ -d "$CONTAINER_IMAGES_BASE_DIR" ]; then
       
       registry=$(echo "$i" | cut -d'/' -f2)
       image=$(echo "$i" | cut -d'/' -f3 | sed s/://g)
-      image_path="${CONTAINER_CACHE}/opt/${registry}_${image}.tgz"
-      mkdir -p "${CONTAINER_CACHE}/opt/"
+      image_path="${CONTAINER_CACHE}/opt/images/${registry}_${image}.tgz"
+      mkdir -p "${CONTAINER_CACHE}/opt/images"
       
       # Check if we already have this image for another class
       # If yes, we just copy the existing file, otherwise download

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -43,26 +43,19 @@ output_dir=.
 ext_dir=$wd/ext
 fai_config_dir=$ext_dir/srv/fai/config
 OUTPUT=seapath.raw
+
 ROLE="$1"
+shift
 HOSTNAME=seapath
 COCKPIT=
-DISKSIZE="60G"
-if [ "$ROLE" != "cluster" ]; then
-    CEPH_DISK=",SEAPATH_CEPH_DISK"
-else
-    CEPH_DISK=
-fi
-ARCH="SEAPATH_AMD64"
-HYPERVISOR=
-CLUSTER=
 DEBUG=
-if [ "$ROLE" == "standalone" ] || [ "$ROLE" == "cluster" ]; then
-    HYPERVISOR=",SEAPATH_HOST"
+DISKSIZE="60G"
+ARCH="SEAPATH_AMD64"
+if [ "$ROLE" != "cluster" ]; then
+    CEPH_DISK=true
+else
+    CEPH_DISK=false
 fi
-if [ "$ROLE" == "cluster" ] || [ "$ROLE" == "observer" ]; then
-    CLUSTER=",SEAPATH_CLUSTER"
-fi
-shift
 
 if ! OPTIONS=$(getopt -o hvs:cn:o:a:xd --long help,version,disk-size:,enable-cockpit,name:,output-dir:,ceph-disk,arch:,hostname:,verbose -- "$@"); then
     print_usage
@@ -106,11 +99,11 @@ while true; do
             fi
             ;;
         -c|--enable-cockpit)
-            COCKPIT=",SEAPATH_COCKPIT"
+            COCKPIT=true
             shift
             ;;
         -d|--enable-debug)
-            DEBUG=",SEAPATH_DBG"
+            DEBUG=true
             shift
             ;;
         -n|--name)
@@ -134,7 +127,7 @@ while true; do
             ;;
         --ceph-disk)
             if [ "$ROLE" == "cluster" ]; then
-                CEPH_DISK=",SEAPATH_CEPH_DISK"
+                CEPH_DISK=true
             else
                 echo "Warning: --ceph-disk option is only applicable for 'cluster' role. Ignoring." >&2
             fi
@@ -170,6 +163,34 @@ if [[ "$ROLE" != "standalone" && "$ROLE" != "cluster" && "$ROLE" != "observer" ]
     echo "Error: Invalid role specified: $ROLE" >&2
     exit 1
 fi
+
+IFS=','
+CLASSES=(FAIBASE DEBIAN GRUB_EFI SEAPATH_COMMON)
+if [ "$ROLE" == "standalone" ] || [ "$ROLE" == "cluster" ]; then
+    CLASSES+=("SEAPATH_HOST")
+fi
+if [ "$ROLE" == "cluster" ] || [ "$ROLE" == "observer" ]; then
+    CLASSES+=("SEAPATH_CLUSTER")
+fi
+if [ "$COCKPIT" = true ]; then
+    CLASSES+=("SEAPATH_COCKPIT")
+fi
+if [ "$DEBUG" = true ]; then
+    CLASSES+=("SEAPATH_DBG")
+fi
+CLASSES+=("$ARCH" SEAPATH_RAW)
+if [ "$CEPH_DISK" = true ]; then
+    CLASSES+=("SEAPATH_CEPH_DISK")
+fi
+CLASSES+=(USERCUSTOMIZATION LAST)
+
+echo "Generate with FAI classes: ${CLASSES[*]}"
+
+function has_class {
+    class_name=$1
+    [[ "${IFS}${CLASSES[*]}${IFS}" =~ ${IFS}${class_name}${IFS} ]]
+    return $?
+}
 
 CONTAINER_ENGINE=(sudo podman)
 echo "We are going to use" "${CONTAINER_ENGINE[*]}"
@@ -209,13 +230,11 @@ sudo wget -O "$fai_config_dir/files/usr/local/bin/cephadm/SEAPATH_CLUSTER" https
 
 # Creating the disk
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
-CLASSES="FAIBASE,DEBIAN,GRUB_EFI,SEAPATH_COMMON,${HYPERVISOR}${CLUSTER}${COCKPIT}${DEBUG},${ARCH},SEAPATH_RAW${CEPH_DISK},USERCUSTOMIZATION,LAST"
-echo "Generate with FAI classes: $CLASSES"
 docker_run bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
-  fai-diskimage -vu ${HOSTNAME} -S${DISKSIZE} -c$CLASSES -s /ext/srv/fai/config /ext/output/${OUTPUT}"
+  fai-diskimage -vu ${HOSTNAME} -S${DISKSIZE} -c${CLASSES[*]} -s /ext/srv/fai/config /ext/output/${OUTPUT}"
 
 # Retrieving the output files from the volume (image and SBOM)
 sudo mv "$ext_dir/output/"* "$output_dir/"

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-version="2.0"
+version="2.1"
+
+set -e
 
 print_usage() {
     echo 'This script generates SEAPATH images base on Debian to be used in the "seapath-installer".'
@@ -210,13 +212,14 @@ function docker_run {
         "$CONTAINER_IMAGE_NAME" "$@"
 }
 
+# Removing the old generated artifacts
+rm -f "$output_dir/${OUTPUT}"{,.bmap,.gz}
+rm -rf "$output_dir/sbom"
+
+# Removing the build directory in case it exists from a precedent build operation.
+sudo rm -rf "$ext_dir"
+
 mkdir -p "$output_dir" "$ext_dir" "/tmp/fai"
-
-rm -f "$output_dir/${OUTPUT}"{,.bmap,.gz} sbom{.spdx,.syft}.json
-# Removing the ext dir in case it exists from a precedent build operation.
-sudo rm -rf "$ext_dir"/*
-
-set -e
 
 # Create the default config space
 docker_run fai-mk-configspace
@@ -282,8 +285,8 @@ docker_run bash -c "\
 sudo mv "$ext_dir/output/"* "$output_dir/"
 sudo chown -R "$(id -u):$(id -g)" "$output_dir/"*
 
-# Clean the build volume
-sudo rm -rf $ext_dir
+# Clean the build directory
+sudo rm -rf "$ext_dir"
 
 if command -v bmaptool >/dev/null ; then
 

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -228,6 +228,48 @@ sudo cp -r "$wd/usercustomization/"* "$fai_config_dir"
 sudo mkdir -p "$fai_config_dir/files/usr/local/bin/cephadm"
 sudo wget -O "$fai_config_dir/files/usr/local/bin/cephadm/SEAPATH_CLUSTER" https://download.ceph.com/rpm-20.2.0/el9/noarch/cephadm
 
+# Adding the container images
+# Process container_images.conf files for all classes that have them
+# This handles images for SEAPATH_CLUSTER, SEAPATH_HOST, USERCUSTOMIZATION, and any other classes
+CONTAINER_IMAGES_CONFIG_DIR="$fai_config_dir/files/etc/container_images.conf"
+
+if [ -d "$CONTAINER_IMAGES_CONFIG_DIR" ]; then
+    image_dir="$fai_config_dir/files/opt/images"
+    sudo mkdir -p "$image_dir"
+    # Process each class configuration file
+    for class_conf_file in "$CONTAINER_IMAGES_CONFIG_DIR"/*; do
+        [ -f "$class_conf_file" ] || continue
+
+        class_name=$(basename "$class_conf_file")
+
+        if ! has_class "$class_name"; then
+            echo "Skipped download of images for class $class_name"
+            continue
+        fi
+        echo "Processing container images for class $class_name"
+
+        # Read images from config file (ignore comments and empty lines)
+        while IFS= read -r i || [ -n "$i" ]; do
+            # Skip empty lines and comments
+            [[ -z "$i" || "$i" =~ ^[[:space:]]*# ]] && continue
+            # Trim whitespace
+            i=$(echo "$i" | xargs)
+            [[ -z "$i" ]] && continue
+
+            registry=$(echo "$i" | cut -d'/' -f2)
+            image=$(echo "$i" | cut -d'/' -f3 | sed s/://g)
+            image_file="$image_dir/${registry}_${image}"
+
+            echo "Downloading image: $i"
+            "${CONTAINER_ENGINE[@]}" pull "$i"
+            echo "Saving image $i to $image_file"
+            "${CONTAINER_ENGINE[@]}" save "$i" --format oci-archive --output "$image_file"
+        done < "$class_conf_file"
+    done
+else
+    echo "Warning: container_images.conf directory not found, skipping image import" >&2
+fi
+
 # Creating the disk
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
 docker_run bash -c "\

--- a/srv_fai_config/class/SEAPATH_COMMON.var
+++ b/srv_fai_config/class/SEAPATH_COMMON.var
@@ -53,3 +53,5 @@ REMOTEGW=10.0.0.1
 # all: DHCP will be enable for all interface
 # [interface]: DHCP will be enable for the interface. e.g enp1s0
 REMOTEDHCP=no
+
+SEAPATH_VERSION=1.2.0

--- a/srv_fai_config/hooks/finish.SEAPATH_COMMON
+++ b/srv_fai_config/hooks/finish.SEAPATH_COMMON
@@ -1,8 +1,41 @@
 #!/bin/bash
 
+shopt -s nullglob
+
+sbom_dir="/ext/output/sbom"
+images_sbom_dir="$sbom_dir/images"
+
+mkdir -p "$sbom_dir" "$images_sbom_dir"
+
+function scan_rootfs {
+    echo "Scanning rootfs at $FAI_ROOT..."
+    syft scan "$FAI_ROOT" \
+        --exclude ./var/lib/containers/ \
+        --source-name "SEAPATH Debian" \
+        --source-supplier "SEAPATH using FAI v$FAI_VERSION" \
+        --source-version "unknown" \
+        -o json=/ext/output/sbom/rootfs.syft.json
+}
+
+function scan_image {
+    image_file=$1
+    image_name=$(basename "$build_image_file")
+
+    echo "Scanning image $image_name..."
+    syft scan "$image_file" \
+        -o json="$images_sbom_dir/$image_name.syft.json"
+}
+
+function scan_all_images {
+    BUILD_IMAGES_DIR="$FAI/files/opt/images"
+
+    echo "Searching for images to scan in $BUILD_IMAGES_DIR..."
+    for build_image_file in "$BUILD_IMAGES_DIR"/*; do
+        scan_image "$build_image_file"
+    done
+}
+
 echo "Starting SBOM generation."
-mkdir /ext/sbom/
-syft scan "$FAI_ROOT" \
-    --exclude ./var/lib/containers/ \
-    -o spdx-json@2.3=/ext/output/sbom.spdx.json \
-    -o json=/ext/output/sbom.syft.json
+
+scan_rootfs
+scan_all_images

--- a/srv_fai_config/hooks/finish.SEAPATH_COMMON
+++ b/srv_fai_config/hooks/finish.SEAPATH_COMMON
@@ -13,7 +13,7 @@ function scan_rootfs {
         --exclude ./var/lib/containers/ \
         --source-name "SEAPATH Debian" \
         --source-supplier "SEAPATH using FAI v$FAI_VERSION" \
-        --source-version "unknown" \
+        --source-version "$SEAPATH_VERSION" \
         -o json=/ext/output/sbom/rootfs.syft.json
 }
 

--- a/srv_fai_config/hooks/finish.SEAPATH_RAW
+++ b/srv_fai_config/hooks/finish.SEAPATH_RAW
@@ -2,6 +2,10 @@
 
 shopt -s nullglob
 
+# We only generate the SBOMs when generating RAW image since we want to get it
+# at build time, not at deploy time. This script would be ran too late when
+# generating an ISO file.
+
 sbom_dir="/ext/output/sbom"
 images_sbom_dir="$sbom_dir/images"
 

--- a/srv_fai_config/scripts/SEAPATH_COMMON/65-container-images
+++ b/srv_fai_config/scripts/SEAPATH_COMMON/65-container-images
@@ -1,39 +1,28 @@
 #!/bin/bash
 
 error=0; trap 'error=$(($?>$error?$?:$error))' ERR # save maximum error code
+shopt -s nullglob
 
-# Copy container images tgz files to /opt
-# This script handles container images for any class that has a container_images.conf file
-# It reads configuration files from all active classes and copies the corresponding image files to /opt/
-# for loading then with "$ROOTCMD podman load -i"
-FAI_CONFIG_DIR="/var/lib/fai/config"
-CONTAINER_IMAGES_DIR="$FAI_CONFIG_DIR/files/etc/container_images.conf"
+BUILD_IMAGES_DIR="$FAI/files/opt/images"
+LOCAL_IMAGES_DIR="/opt/images"
 
-# Collect all images from all classes that have container_images.conf files
-# We check all possible classes and copy images if the config file exists
-for class_conf_file in "$CONTAINER_IMAGES_DIR"/*; do
-    [ -f "$class_conf_file" ] || continue
-    
-    class_name=$(basename "$class_conf_file")
-    echo "Processing container images for class: $class_name"
-    
-    # Read images from config file (ignore comments and empty lines)
-    while IFS= read -r i || [ -n "$i" ]; do
-        # Skip empty lines and comments
-        [[ -z "$i" || "$i" =~ ^[[:space:]]*# ]] && continue
-        # Trim whitespace
-        i=$(echo "$i" | xargs)
-        [[ -z "$i" ]] && continue
-        
-        registry=$(echo "$i" | cut -d'/' -f2)
-        image=$(echo "$i" | cut -d'/' -f3 | sed s/://g)
+mkdir -p "$FAI_ROOT$LOCAL_IMAGES_DIR"
 
-        # this is to prevent shellcheck SC2154 because $target is injected at runtime
-        "${target:?FAI variable 'target' must be set}"
+# Collect all images that have been saved to the build directory and load them
+# in the guest local image storage.
+# No need to parse the container_images.conf files again since the image
+# generation script already does it and save the needed images in /opt/images.
+for build_image_file in "$BUILD_IMAGES_DIR"/*; do
+    image_name=$(basename "$build_image_file")
+    echo "Loading container image $image_name"
+    image_path="$LOCAL_IMAGES_DIR/$image_name"
 
-        cp "$FAI_CONFIG_DIR/files/opt/${registry}_${image}.tgz" "$target/opt/"
-        $ROOTCMD podman load -i "/opt/${registry}_${image}.tgz"
-        rm -f "$target/opt/${registry}_${image}.tgz"
+    # We copy the image since chrooted podman does not have access to the
+    # files outside its local filesystem.
+    cp "$build_image_file" "$FAI_ROOT$image_path"
+    $ROOTCMD podman load -i "$image_path"
+    rm -f "$FAI_ROOT$image_path"
 
-    done < "$class_conf_file"
+    # NOTE: the original image file is not removed since it will be later used
+    # for SBOM generation
 done


### PR DESCRIPTION
This PR adds SBOM generation for container images loaded during the build.

Each image generates one SBOM under $output/sbom/images.

For this to work, container image download has been added to the generate_seapath_image script. It correctly handles which class is enabled to only download the necessary images.
This allowed a simplification of the image loading FAI script.

Also added the necessary flagsto the rootfs scanning command so no warnings are raised during SBOM generation. This required adding a SEAPATH_VERSION variable.

---
I tested the changes by deploying both an ISO and a RAW image and it works, container images are shown when running `podman image ls`.