### PR TITLE
Debian 12 package_config/SEAPATH_HOST: add missing libvirt python dependencies

### DIFF
--- a/srv_fai_config/package_config/SEAPATH_HOST
+++ b/srv_fai_config/package_config/SEAPATH_HOST
@@ -20,6 +20,8 @@ openvswitch-switch
 patch
 python3-flaskext.wtf
 python3-pip
+python3-libvirt
+python3-lxml
 python3-xmltodict
 qemu-block-extra
 qemu-system-x86


### PR DESCRIPTION
We need to add the missing python dependencies for libvirt to be able to use Ansible libvirt modules.