### PR TITLE
generate_images: build versioned artifacts for all roles

### DIFF
--- a/.github/workflows/ci-build13.yml
+++ b/.github/workflows/ci-build13.yml
@@ -24,12 +24,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Make build_iso.sh executable (if needed)
-        run: chmod +x .release/generate_images.sh
+      - name: Make ci_build.sh executable (if needed)
+        run: chmod +x .release/ci_build.sh
 
-      - name: Run release script
+      - name: Run CI build script
         run: |
-          .release/generate_images.sh
+          .release/ci_build.sh
         shell: bash
 
       - name: Check exit code

--- a/.release/ci_build.sh
+++ b/.release/ci_build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd "$(dirname "$0")"
+cp -f grub.cfg ../etc_fai/grub.cfg
+cp -f class_USERCUSTOMIZATION.var ../usercustomization/class/USERCUSTOMIZATION.var
+cd ..
+./build_iso.sh
+./build_qcow2.sh
+./generate_seapath_image.sh cluster

--- a/.release/generate_images.sh
+++ b/.release/generate_images.sh
@@ -1,11 +1,105 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
+
+PUBLISH=false
+
+print_usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--publish] [-h|--help]
+
+Build SEAPATH release artifacts (ISO, QCOW2, and standalone/cluster/observer
+rootfs images), rename them with the current git-described version, and
+optionally publish them to the matching GitHub release.
+
+Options:
+  --publish    Upload the renamed artifacts to the GitHub release matching
+               the current tag. Requires being on an exact, clean tag and
+               that the release already exists on GitHub.
+  -h, --help   Show this help message.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --publish)
+            PUBLISH=true
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            print_usage >&2
+            exit 1
+            ;;
+    esac
+done
 
 cd "$(dirname "$0")"
 cp -f grub.cfg ../etc_fai/grub.cfg
 cp -f class_USERCUSTOMIZATION.var ../usercustomization/class/USERCUSTOMIZATION.var
 cd ..
+
+if ! command -v bmaptool >/dev/null; then
+    echo "Error: bmaptool is not installed. Install it before running this script." >&2
+    exit 1
+fi
+
+VERSION=$(git describe --tags --dirty)
+
+if $PUBLISH; then
+    if ! command -v gh >/dev/null; then
+        echo "Error: gh (GitHub CLI) is not installed. Install it before using --publish." >&2
+        exit 1
+    fi
+    if ! TAG=$(git describe --tags --exact-match 2>/dev/null); then
+        echo "Error: --publish requires being on an exact git tag (got: ${VERSION})." >&2
+        exit 1
+    fi
+    if [[ "$(git describe --tags --exact-match --dirty)" == *-dirty ]]; then
+        echo "Error: --publish requires a clean worktree (tag ${TAG} is dirty)." >&2
+        exit 1
+    fi
+    if ! gh release view "$TAG" >/dev/null 2>&1; then
+        echo "Error: GitHub release ${TAG} does not exist. Create it on GitHub first, then re-run with --publish." >&2
+        exit 1
+    fi
+fi
+
+ISO="seapath-${VERSION}-debian-autoinstaller-fai.iso"
+QCOW="seapath-${VERSION}-guest.qcow2"
+STANDALONE="seapath-${VERSION}-generic-standalone.rootfs"
+CLUSTER="seapath-${VERSION}-generic-cluster.rootfs"
+OBSERVER="seapath-${VERSION}-generic-observer.rootfs"
+
+build_role() {
+    local role="$1"
+    local base="$2"
+    shift 2
+    ./generate_seapath_image.sh "$role" "$@"
+    mv -f seapath.raw.gz   "${base}.raw.gz"
+    mv -f seapath.raw.bmap "${base}.raw.bmap"
+}
+
 ./build_iso.sh
+mv -f seapath.iso "$ISO"
+
 ./build_qcow2.sh
-./generate_seapath_image.sh cluster
+mv -f seapath-vm.qcow2 "$QCOW"
+
+build_role standalone "$STANDALONE" -c
+build_role cluster    "$CLUSTER"    -c --ceph-disk
+build_role observer   "$OBSERVER"   -c
+
+if $PUBLISH; then
+    gh release upload "$TAG" \
+        "$ISO" \
+        "$QCOW" \
+        "${STANDALONE}.raw.gz" "${STANDALONE}.raw.bmap" \
+        "${CLUSTER}.raw.gz"    "${CLUSTER}.raw.bmap" \
+        "${OBSERVER}.raw.gz"   "${OBSERVER}.raw.bmap" \
+        --clobber
+fi


### PR DESCRIPTION
Rework .release/generate_images.sh to build the ISO, QCOW2, and the three rootfs roles (standalone, cluster, observer), rename each output with the version reported by git describe --tags --dirty, and add a --publish option that uploads the artifacts to the matching GitHub release via gh. The script now fails early if bmaptool is missing, and --publish refuses to run unless the build is on an exact, clean tag with an existing GitHub release.