### PR TITLE
workflows: migrate from self-hosted to GitHub-hosted runner

### DIFF
--- a/.github/workflows/build-and-s3-upload.yml
+++ b/.github/workflows/build-and-s3-upload.yml
@@ -15,10 +15,15 @@ permissions: read-all
 jobs:
   generate-and-upload:
     name: Generate images and upload to S3
-    runs-on: [self-hosted, runner-RTE-cibuild13]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y podman podman-compose bmap-tools pigz
 
       - name: Make image generator executable
         run: chmod +x .release/generate_images.sh
@@ -35,6 +40,20 @@ jobs:
       - name: Generate release images
         run: |
           .release/generate_images.sh --tag ${BUILD_ID}
+
+      - name: Collect FAI logs on failure
+        if: failure()
+        run: |
+          sudo tar -czf fai-logs.tar.gz -C /tmp fai
+          sudo chown "$(id -u):$(id -g)" fai-logs.tar.gz
+
+      - name: Upload FAI logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fai-logs-${{ github.run_id }}
+          path: fai-logs.tar.gz
+          if-no-files-found: ignore
 
       - name: Upload to S3
         env:

--- a/.github/workflows/ci-build13.yml
+++ b/.github/workflows/ci-build13.yml
@@ -19,10 +19,15 @@ permissions:
 
 jobs:
   CI-build:
-    runs-on: [self-hosted, runner-RTE-cibuild13]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y podman podman-compose bmap-tools pigz
 
       - name: Make ci_build.sh executable (if needed)
         run: chmod +x .release/ci_build.sh
@@ -31,6 +36,20 @@ jobs:
         run: |
           .release/ci_build.sh
         shell: bash
+
+      - name: Collect FAI logs on failure
+        if: failure()
+        run: |
+          sudo tar -czf fai-logs.tar.gz -C /tmp fai
+          sudo chown "$(id -u):$(id -g)" fai-logs.tar.gz
+
+      - name: Upload FAI logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fai-logs-${{ github.run_id }}
+          path: fai-logs.tar.gz
+          if-no-files-found: ignore
 
       - name: Check exit code
         run: echo "Script exited successfully!"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ RUN echo "deb http://fai-project.org/download trixie koeln" > /etc/apt/sources.l
     apt-get -y install qemu-utils && \
     apt-get -y install reprepro xorriso squashfs-tools vim udev
 
+# Disable udev synchronization for device-mapper/LVM: in privileged containers
+# sharing the host's /dev, udev may not create /dev/<vgname>/<lvname> symlinks
+# in time for mkfs to find them after lvcreate (race condition). This makes
+# libdevmapper create the device nodes itself instead of waiting for udev.
+ENV DM_DISABLE_UDEV=1
+
 # Syft is a tool for SBOM generation
 # Pin version to avoid querying GitHub's releases API at build time
 ARG SYFT_VERSION=v1.18.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ RUN echo "deb http://fai-project.org/download trixie koeln" > /etc/apt/sources.l
     apt-get -y install reprepro xorriso squashfs-tools vim udev
 
 # Syft is a tool for SBOM generation
-RUN curl -sSfL https://get.anchore.io/syft | sh -s -- -b /usr/local/bin
+# Pin version to avoid querying GitHub's releases API at build time
+ARG SYFT_VERSION=v1.18.1
+RUN curl -sSfL https://get.anchore.io/syft | sh -s -- -b /usr/local/bin ${SYFT_VERSION}

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -15,6 +15,8 @@ rm -f $output_dir/seapath.iso
 
 set -e
 
+"${CONTAINER_ENGINE[@]}" build "$wd" --tag fai
+
 if [ ! -f "$wd"/etc_fai/grub.cfg ]; then
   cp "$wd"/etc_fai/grub_base.cfg "$wd"/etc_fai/grub.cfg
 fi

--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -88,17 +88,26 @@ fi
 
 # Creating the VM
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
-# patches GRUB_EFI/10-setup: "efibootmgr -v" runs on the build host (not in the
-# chroot) for LVM-backed boot devices, but build hosts have no EFI firmware, so
-# it fails with "EFI variables are not supported on this system" and aborts the
-# whole script. It is only an informational dump of NVRAM boot entries, so we
-# can safely ignore its failure.
+# patches GRUB_EFI/10-setup:
+# - "efibootmgr -v" runs on the build host (not in the chroot) for LVM-backed
+#   boot devices, but build hosts have no EFI firmware, so it fails with "EFI
+#   variables are not supported on this system" and aborts the whole script.
+#   It is only an informational dump of NVRAM boot entries, so we can safely
+#   ignore its failure.
+# - for LVM-backed boot devices, the script calls "grub-install $opts $GROOT"
+#   without --force-extra-removable/--no-nvram (unlike its loop-device branch),
+#   so the resulting image gets neither a usable NVRAM entry (the build host
+#   has no EFI firmware to write one to, and none could be embedded in a
+#   portable image anyway) nor a fallback bootloader at \EFI\BOOT\BOOTX64.EFI.
+#   Fresh UEFI firmware then has nothing to boot and drops to the UEFI Shell.
+#   Force the same flags as the loop-device branch so the image is bootable.
 CLASSES="DEBIAN,FAIBASE,FRENCH,TRIXIE64,SEAPATH_COMMON,GRUB_EFI,SEAPATH_RAW,${seapatharch},SEAPATH_VM,USERCUSTOMIZATION,BUILD_QCOW2,LAST"
 "${COMPOSECMD[@]}" -f "${COMPOSE_FILE}" run --rm fai-cd bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
   sed -i -e \"s/efibootmgr -v/efibootmgr -v || true/\" /ext/srv/fai/config/scripts/GRUB_EFI/10-setup && \
+  sed -i -e \"s/grub-install \\\$opts \\\"\\\$GROOT\\\"/grub-install \\\$opts --force-extra-removable --no-nvram \\\"\\\$GROOT\\\"/\" /ext/srv/fai/config/scripts/GRUB_EFI/10-setup && \
   fai-diskimage -vu seapath-vm -S${DISKSIZE} -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"
 
 # Retrieving the ISO from the volume

--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -88,11 +88,17 @@ fi
 
 # Creating the VM
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
+# patches GRUB_EFI/10-setup: "efibootmgr -v" runs on the build host (not in the
+# chroot) for LVM-backed boot devices, but build hosts have no EFI firmware, so
+# it fails with "EFI variables are not supported on this system" and aborts the
+# whole script. It is only an informational dump of NVRAM boot entries, so we
+# can safely ignore its failure.
 CLASSES="DEBIAN,FAIBASE,FRENCH,TRIXIE64,SEAPATH_COMMON,GRUB_EFI,SEAPATH_RAW,${seapatharch},SEAPATH_VM,USERCUSTOMIZATION,BUILD_QCOW2,LAST"
 "${COMPOSECMD[@]}" -f "${COMPOSE_FILE}" run --rm fai-cd bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
+  sed -i -e \"s/efibootmgr -v/efibootmgr -v || true/\" /ext/srv/fai/config/scripts/GRUB_EFI/10-setup && \
   fai-diskimage -vu seapath-vm -S${DISKSIZE} -c$CLASSES -s /ext/srv/fai/config /ext/seapath-vm.qcow2"
 
 # Retrieving the ISO from the volume

--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -59,6 +59,8 @@ rm -f $output_dir/seapath-vm.qcow2
 
 set -ex
 
+"${CONTAINER_ENGINE[@]}" build "$wd" --tag fai
+
 rm -rf "$wd"/build_tmp/*
 cp -r "$wd/srv_fai_config/"* "$wd/build_tmp"
 cp -r "$wd/usercustomization/"* "$wd/build_tmp"

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -282,16 +282,25 @@ fi
 
 # Creating the disk
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
-# patches GRUB_EFI/10-setup: "efibootmgr -v" runs on the build host (not in the
-# chroot) for LVM-backed boot devices, but build hosts have no EFI firmware, so
-# it fails with "EFI variables are not supported on this system" and aborts the
-# whole script. It is only an informational dump of NVRAM boot entries, so we
-# can safely ignore its failure.
+# patches GRUB_EFI/10-setup:
+# - "efibootmgr -v" runs on the build host (not in the chroot) for LVM-backed
+#   boot devices, but build hosts have no EFI firmware, so it fails with "EFI
+#   variables are not supported on this system" and aborts the whole script.
+#   It is only an informational dump of NVRAM boot entries, so we can safely
+#   ignore its failure.
+# - for LVM-backed boot devices, the script calls "grub-install $opts $GROOT"
+#   without --force-extra-removable/--no-nvram (unlike its loop-device branch),
+#   so the resulting image gets neither a usable NVRAM entry (the build host
+#   has no EFI firmware to write one to, and none could be embedded in a
+#   portable image anyway) nor a fallback bootloader at \EFI\BOOT\BOOTX64.EFI.
+#   Fresh UEFI firmware then has nothing to boot and drops to the UEFI Shell.
+#   Force the same flags as the loop-device branch so the image is bootable.
 docker_run bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
   sed -i -e \"s/efibootmgr -v/efibootmgr -v || true/\" /ext/srv/fai/config/scripts/GRUB_EFI/10-setup && \
+  sed -i -e \"s/grub-install \\\$opts \\\"\\\$GROOT\\\"/grub-install \\\$opts --force-extra-removable --no-nvram \\\"\\\$GROOT\\\"/\" /ext/srv/fai/config/scripts/GRUB_EFI/10-setup && \
   fai-diskimage -vu ${HOSTNAME} -S${DISKSIZE} -c${CLASSES[*]} -s /ext/srv/fai/config /ext/output/${OUTPUT}"
 
 # Retrieving the output files from the volume (image and SBOM)

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -282,10 +282,16 @@ fi
 
 # Creating the disk
 # patches /sbin/install_packages (bug in the process of being corrected upstream)
+# patches GRUB_EFI/10-setup: "efibootmgr -v" runs on the build host (not in the
+# chroot) for LVM-backed boot devices, but build hosts have no EFI firmware, so
+# it fails with "EFI variables are not supported on this system" and aborts the
+# whole script. It is only an informational dump of NVRAM boot entries, so we
+# can safely ignore its failure.
 docker_run bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \
   sed -i -e \"s/-c -o compression_type=zstd qcow2/qcow2/\" /usr/sbin/fai-diskimage && \
+  sed -i -e \"s/efibootmgr -v/efibootmgr -v || true/\" /ext/srv/fai/config/scripts/GRUB_EFI/10-setup && \
   fai-diskimage -vu ${HOSTNAME} -S${DISKSIZE} -c${CLASSES[*]} -s /ext/srv/fai/config /ext/output/${OUTPUT}"
 
 # Retrieving the output files from the volume (image and SBOM)


### PR DESCRIPTION
Switch runs-on from self-hosted runner to ubuntu-latest and install required build dependencies (podman, podman-compose, bmap-tools, pigz) as a workflow step.