### PR TITLE
Fix SEAPATH Debian raw images metadatas

### DIFF
--- a/.release/generate_images.sh
+++ b/.release/generate_images.sh
@@ -58,6 +58,7 @@ fi
 if [ -z "$VERSION" ]; then
   VERSION=$(git describe --tags --dirty)
 fi
+export VERSION
 
 if $PUBLISH; then
     if ! command -v gh >/dev/null; then

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -47,7 +47,13 @@ if [ "${1,,}" == "-h" ] || [ "${1,,}" == "--help" ]; then
 fi
 
 wd=$(dirname "$0")
-SEAPATH_VERSION=$(git -C "$wd" describe --tags --dirty 2>/dev/null || echo "unknown")
+
+if [ -z "$VERSION" ]; then
+    SEAPATH_VERSION=$(git -C "$wd" describe --tags --dirty 2>/dev/null || echo "unknown")
+else
+    SEAPATH_VERSION=$VERSION
+fi
+
 output_dir=.
 ext_dir=$wd/ext
 fai_config_dir=$ext_dir/srv/fai/config

--- a/generate_seapath_metadata.py
+++ b/generate_seapath_metadata.py
@@ -8,13 +8,25 @@ from os import environ
 working_dir = environ.get("output_dir", "")
 bmap_file = f"{environ.get('OUTPUT', '')}.bmap"
 
+ImageName = ""
+ImageDescription = ""
+
 role = environ.get("role", "")
 role = role.lower()
 
 if "standalone" in role:
+    ImageName = "SEAPATH Debian hypervisor"
+    ImageDescription = "A production hypervisor image for a SEAPATH standalone setup"
     setup = "Standalone"
-else:
+elif "cluster" in role:
+    ImageName = "SEAPATH Debian hypervisor"
+    ImageDescription = "A production hypervisor image for a SEAPATH cluster setup"
     setup = "Cluster"
+elif "observer" in role:
+    ImageName = "SEAPATH Debian observer"
+    ImageDescription = "A production observer image for a SEAPATH cluster setup"
+    setup = "Cluster"
+
 
 bmap_path = Path(working_dir) / bmap_file
 if not bmap_path.exists():
@@ -26,9 +38,9 @@ root = bmap_tree.getroot()
 seapath_version = environ.get("SEAPATH_VERSION", "unknown")
 
 for tag, value in [
-    ("ImageName", "SEAPATH Debian"),
+    ("ImageName", ImageName),
     ("ImageVersion", seapath_version),
-    ("ImageDescription", "A production image for SEAPATH"),
+    ("ImageDescription", ImageDescription),
     ("ImageSetup", setup),
     ("ImageFlavor", "Debian"),
 ]:

--- a/srv_fai_config/class/SEAPATH_COMMON.var
+++ b/srv_fai_config/class/SEAPATH_COMMON.var
@@ -54,4 +54,4 @@ REMOTEGW=10.0.0.1
 # [interface]: DHCP will be enable for the interface. e.g enp1s0
 REMOTEDHCP=no
 
-SEAPATH_VERSION=1.2.0
+SEAPATH_VERSION=2.0.0


### PR DESCRIPTION
Hello, 
This PR fixes minor issues on generated metadatas of SEAPATH Debian images:
* Improve name and description, in order to distinguish hypervisor from observer images
* Fix unknown image version when generating images with the release script