### PR TITLE
Add cloud-init support to SEAPATH images

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,17 @@ To build a basic VM for the SEAPATH project, simply launch the script `build_qco
 Note that the lvm2 package must be installed on your build host.
 
 Please refer to the configuration section above. To customize the Virtual Machine properly, the file SEAPATH_COMMON.var must be filled.
+
+### cloud-init
+
+cloud-init is **not** installed by default. To build a VM image that can be
+provisioned with cloud-init, enable the optional `SEAPATH_CLOUD_INIT` class:
+
+```
+build_qcow2.sh --cloud-init
+```
+
+This installs `cloud-init` in the image and configures it to use only the
+NoCloud datasource (`/etc/cloud/cloud.cfg.d/90_seapath.cfg`). At deployment time
+the SEAPATH ansible `deploy_vms` roles attach a NoCloud seed disk to configure
+the guest (hostname, users, network, packages, ...) on first boot.

--- a/build_qcow2.sh
+++ b/build_qcow2.sh
@@ -5,8 +5,9 @@ output_dir=.
 COMPOSE_FILE="$(realpath "$wd"/podman-compose.yml)"
 
 DISKSIZE="10G"
-if ! OPTIONS=$(getopt -o hvs: --long help,version,vmdisksize: -- "$@"); then
-    echo "Usage: $0 [-h|--help] [-v|--version] [-s|--vmdisksize SIZE]" >&2
+CLOUD_INIT=
+if ! OPTIONS=$(getopt -o hvs:c --long help,version,vmdisksize:,cloud-init -- "$@"); then
+    echo "Usage: $0 [-h|--help] [-v|--version] [-s|--vmdisksize SIZE] [-c|--cloud-init]" >&2
     exit 1
 fi
 eval set -- "$OPTIONS"
@@ -18,6 +19,7 @@ while true; do
             echo "  -h, --help           Display this help message"
             echo "  -v, --version        Display version information"
             echo "  -s, --vmdisksize SIZE Specify the VM disk size (required argument)"
+            echo "  -c, --cloud-init     Include cloud-init in the VM image (SEAPATH_CLOUD_INIT class)"
             exit 0
             ;;
         -v|--version)
@@ -33,6 +35,10 @@ while true; do
                 echo "Error: The -s|--vmdisksize option requires an argument." >&2
                 exit 1
             fi
+            ;;
+        -c|--cloud-init)
+            CLOUD_INIT=true
+            shift
             ;;
         --)
             shift
@@ -101,7 +107,11 @@ fi
 #   portable image anyway) nor a fallback bootloader at \EFI\BOOT\BOOTX64.EFI.
 #   Fresh UEFI firmware then has nothing to boot and drops to the UEFI Shell.
 #   Force the same flags as the loop-device branch so the image is bootable.
-CLASSES="DEBIAN,FAIBASE,FRENCH,TRIXIE64,SEAPATH_COMMON,GRUB_EFI,SEAPATH_RAW,${seapatharch},SEAPATH_VM,USERCUSTOMIZATION,BUILD_QCOW2,LAST"
+CLOUD_INIT_CLASS=
+if [ "$CLOUD_INIT" = true ]; then
+    CLOUD_INIT_CLASS="SEAPATH_CLOUD_INIT,"
+fi
+CLASSES="DEBIAN,FAIBASE,FRENCH,TRIXIE64,SEAPATH_COMMON,GRUB_EFI,SEAPATH_RAW,${seapatharch},SEAPATH_VM,${CLOUD_INIT_CLASS}USERCUSTOMIZATION,BUILD_QCOW2,LAST"
 "${COMPOSECMD[@]}" -f "${COMPOSE_FILE}" run --rm fai-cd bash -c "\
   sed -i -e \"s|-f \\\"\\\$FAI_ROOT/usr/sbin/apt-cache|-f \\\"\\\$FAI_ROOT/usr/bin/apt-cache|\" /sbin/install_packages && \
   sed -i -e \"s/ --allow-change-held-packages//\" /sbin/install_packages && \

--- a/srv_fai_config/files/etc/cloud/cloud.cfg.d/90_seapath.cfg/SEAPATH_CLOUD_INIT
+++ b/srv_fai_config/files/etc/cloud/cloud.cfg.d/90_seapath.cfg/SEAPATH_CLOUD_INIT
@@ -1,0 +1,13 @@
+# SEAPATH cloud-init configuration
+#
+# SEAPATH VMs provisioned with cloud-init use a NoCloud seed disk attached at
+# deployment time (see the seapath ansible deploy_vms roles). Restrict the
+# datasource detection to NoCloud so cloud-init does not probe cloud metadata
+# services that do not exist in this environment.
+datasource_list: [ NoCloud, None ]
+
+# Render the network configuration through netplan (netplan.io is installed and
+# backed by systemd-networkd, which SEAPATH enables for the VM).
+system_info:
+  network:
+    renderers: [ netplan ]

--- a/srv_fai_config/package_config/SEAPATH_CLOUD_INIT
+++ b/srv_fai_config/package_config/SEAPATH_CLOUD_INIT
@@ -1,0 +1,3 @@
+PACKAGES install-norec
+cloud-init
+cloud-guest-utils

--- a/srv_fai_config/scripts/SEAPATH_CLOUD_INIT/20-cloud-init
+++ b/srv_fai_config/scripts/SEAPATH_CLOUD_INIT/20-cloud-init
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+error=0; trap 'error=$(($?>$error?$?:$error))' ERR # save maximum error code
+
+fcopy -M /etc/cloud/cloud.cfg.d/90_seapath.cfg
+
+$ROOTCMD systemctl enable cloud-init-local.service
+$ROOTCMD systemctl enable cloud-init.service
+$ROOTCMD systemctl enable cloud-config.service
+$ROOTCMD systemctl enable cloud-final.service


### PR DESCRIPTION
Adds [cloud-init](https://cloudinit.readthedocs.io/) support to SEAPATH VM images so that guest VMs can be configured (hostname, users, SSH keys, network, packages, `runcmd`, ...) on first boot, instead of having to do it by hand.

This is the `build_debian_iso` side of the feature. The companion change lives in `seapath/ansible` (`deploy_vms` roles + new `cloud_init_seed` role), which builds a NoCloud seed disk at deployment time and attaches it to the VM.

## How it works

ansible roles build a small seed image (filesystem labelled `cidata`, holding `meta-data` / `user-data` / `network-config`) on the Ansible controller with `cloud-localds`, and attach it to the VM as an extra disk. cloud-init in the guest discovers it by its `CIDATA` label and applies the configuration on first boot.

## Changes

cloud-init is **not** installed by default. It is provided through a new **opt-in FAI class `SEAPATH_CLOUD_INIT`**, so VM images that don't need it are unchanged.
  
The class:
- installs `cloud-init` (and `cloud-guest-utils`),
- adds `/etc/cloud/cloud.cfg.d/90_seapath.cfg`:
  - restricts the datasource list to `NoCloud` (no probing of non-existent cloud metadata services),
  - renders the network config through netplan (already backed by systemd-networkd on SEAPATH),
- enables the cloud-init services (FAI script `SEAPATH_CLOUD_INIT/20-cloud-init`).

`build_qcow2.sh` gets a new `--cloud-init` (`-c`) flag that enables the class. Without it, the produced image and its FAI class list are identical to before.

## Notes
- No extra dependency is added to the base/hypervisor image: the seed is built on the Ansible controller (`cloud-localds`, added to the `cqfd` container on the ansible side), not on the hypervisor.
- The feature is also opt-in per VM on the ansible side: a VM without a `cloud_init` block keeps the previous behaviour, and no seed disk is created.
  
## Testing
- `build_qcow2.sh` (no flag): confirm the image is unchanged and cloud-init is **absent**.
- `build_qcow2.sh --cloud-init`: confirm `cloud-init` is installed and `/etc/cloud/cloud.cfg.d/90_seapath.cfg` is present.
- Deploy a VM with a `cloud_init` block (see the companion ansible PR) and check `cloud-init status --long` reports `done` inside the guest.

## Companion PR
- seapath/ansible: https://github.com/seapath/ansible/pull/953