### PR TITLE
Resolve Ceph version at build time for cephadm and container image

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,4 +18,4 @@ jobs:
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
         env:
-          SHELLCHECK_OPTS: -e SC2086 -e SC2154
+          SHELLCHECK_OPTS: -x -e SC2086 -e SC2154

--- a/README.md
+++ b/README.md
@@ -83,10 +83,29 @@ By default, the ISO includes container images needed for SEAPATH functionality. 
 * You can override a class by creating `usercustomization/files/etc/container_images.conf/CLASS_NAME`
 * You can add images by creating `usercustomization/files/etc/container_images.conf/USERCUSTOMIZATION`
 * Each class has its own file, so they don't override each other - all active classes' images are combined
-* The file format is one image per line as `registry/image:tag` (e.g., `quay.io/ceph/ceph:v20.2.0`)
+* The file format is one image per line as `registry/image:tag` (e.g., `docker.io/library/registry:2`)
 * Lines starting with `#` are treated as comments and ignored, as well as empty lines
 
 During installation, the script reads all configuration files from active classes and copies the corresponding image files to `/opt/`, and then call "podman load -i" on each one of them to load then in the podman local registry.
+
+**Ceph version (cluster builds):**
+
+When building with the `SEAPATH_CLUSTER` class (`build_iso.sh` or `generate_seapath_image.sh` with the `cluster` role), the build scripts automatically:
+
+* download the matching `cephadm` binary from `download.ceph.com`
+* pull the corresponding `quay.io/ceph/ceph` container image
+
+By default, the latest Ceph release available on `download.ceph.com` is used. No manual update is required after cloning the repository.
+
+To pin a specific Ceph version instead, create `usercustomization/class/ceph.version` with a single line such as `20.2.0`. This file is not tracked by git (see `.gitignore`). See `ceph.version.example` at the repository root for the expected format.
+
+Resolution order:
+
+1. `CEPH_VERSION` environment variable (one-off override, e.g. `CEPH_VERSION=20.2.0 ./build_iso.sh`)
+2. `usercustomization/class/ceph.version` (persistent local override)
+3. latest release from `download.ceph.com`
+
+The Ceph container image line in `SEAPATH_CLUSTER` is injected at build time; you do not need to maintain it manually in `container_images.conf`.
 
 more info: https://fai-project.org/fai-guide
 

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -248,11 +248,13 @@ fi
 # Adding the SEAPATH workspace
 "${CONTAINER_ENGINE[@]}" cp "$wd"/build_tmp/. fai-setup:/ext/srv/fai/config/
 
-# Adding the cephadm binary
-echo mkdir -p /tmp/cephadm/usr/local/bin/cephadm
+# Adding the cephadm binary and patching Ceph container image version
+# shellcheck source=scripts/lib/ceph_version.sh
+source "$wd/scripts/lib/ceph_version.sh"
+patch_ceph_container_image "$wd/build_tmp/files/etc/container_images.conf/SEAPATH_CLUSTER"
+
 mkdir -p /tmp/cephadm/usr/local/bin/cephadm
-echo wget -O /tmp/cephadm/usr/local/bin/cephadm/SEAPATH_CLUSTER https://download.ceph.com/rpm-20.2.0/el9/noarch/cephadm
-wget -O /tmp/cephadm/usr/local/bin/cephadm/SEAPATH_CLUSTER https://download.ceph.com/rpm-20.2.0/el9/noarch/cephadm
+download_cephadm /tmp/cephadm/usr/local/bin/cephadm/SEAPATH_CLUSTER
 echo "${CONTAINER_ENGINE[@]}" cp /tmp/cephadm/. fai-setup:/ext/srv/fai/config/files/
 "${CONTAINER_ENGINE[@]}" cp /tmp/cephadm/. fai-setup:/ext/srv/fai/config/files/
 # Adding the container images

--- a/ceph.version.example
+++ b/ceph.version.example
@@ -1,0 +1,5 @@
+# Copy to usercustomization/class/ceph.version to pin a Ceph release.
+# This file is not tracked by git (see .gitignore).
+#
+# Example:
+20.2.0

--- a/generate_seapath_image.sh
+++ b/generate_seapath_image.sh
@@ -241,8 +241,15 @@ sudo mkdir "$ext_dir/output"
 sudo cp -r "$wd/srv_fai_config/"* "$fai_config_dir"
 sudo cp -r "$wd/usercustomization/"* "$fai_config_dir"
 
+# shellcheck source=scripts/lib/ceph_version.sh
+source "$wd/scripts/lib/ceph_version.sh"
+patch_ceph_container_image "$fai_config_dir/files/etc/container_images.conf/SEAPATH_CLUSTER"
+
+cephadm_tmp=$(mktemp)
+download_cephadm "$cephadm_tmp"
 sudo mkdir -p "$fai_config_dir/files/usr/local/bin/cephadm"
-sudo wget -O "$fai_config_dir/files/usr/local/bin/cephadm/SEAPATH_CLUSTER" https://download.ceph.com/rpm-20.2.0/el9/noarch/cephadm
+sudo install -m 0755 "$cephadm_tmp" "$fai_config_dir/files/usr/local/bin/cephadm/SEAPATH_CLUSTER"
+rm -f "$cephadm_tmp"
 
 # Adding the container images
 # Process container_images.conf files for all classes that have them

--- a/scripts/lib/ceph_version.sh
+++ b/scripts/lib/ceph_version.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Resolve Ceph version and download cephadm / container image at build time.
+#
+# Version resolution order:
+#   1. CEPH_VERSION environment variable
+#   2. usercustomization/class/ceph.version (not tracked by git)
+#   3. latest release from download.ceph.com
+
+_ceph_lib_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT="${REPO_ROOT:-$(cd "$_ceph_lib_dir/../.." && pwd)}"
+CEPH_VERSION_OVERRIDE_FILE="${REPO_ROOT}/usercustomization/class/ceph.version"
+
+_load_ceph_version_from_file() {
+    local file="$1"
+    local version
+
+    [ -f "$file" ] || return 1
+
+    version=$(
+        grep -Ev '^[[:space:]]*(#|$)' "$file" | head -1 | tr -d '[:space:]'
+    )
+    if [ -z "$version" ]; then
+        return 1
+    fi
+    if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Error: invalid Ceph version '$version' in $file" >&2
+        return 1
+    fi
+
+    CEPH_VERSION="$version"
+}
+
+resolve_ceph_version() {
+    if [ -n "${CEPH_VERSION:-}" ]; then
+        echo "Using Ceph version from CEPH_VERSION: ${CEPH_VERSION}" >&2
+        return 0
+    fi
+
+    if _load_ceph_version_from_file "$CEPH_VERSION_OVERRIDE_FILE"; then
+        echo "Using Ceph version from $CEPH_VERSION_OVERRIDE_FILE: ${CEPH_VERSION}" >&2
+        return 0
+    fi
+
+    CEPH_VERSION=$(
+        curl -sf https://download.ceph.com/ \
+            | grep -oE 'rpm-[0-9]+\.[0-9]+\.[0-9]+' \
+            | sed 's/rpm-//' \
+            | sort -Vu \
+            | tail -1
+    )
+
+    if [ -z "$CEPH_VERSION" ]; then
+        echo "Error: could not determine the latest Ceph version" >&2
+        return 1
+    fi
+
+    echo "Using latest Ceph version: ${CEPH_VERSION}" >&2
+}
+
+cephadm_download_url() {
+    resolve_ceph_version
+    echo "https://download.ceph.com/rpm-${CEPH_VERSION}/el9/noarch/cephadm"
+}
+
+ceph_container_image() {
+    resolve_ceph_version
+    echo "quay.io/ceph/ceph:v${CEPH_VERSION}"
+}
+
+download_cephadm() {
+    local dest="$1"
+    local url
+    url=$(cephadm_download_url)
+    echo "Downloading cephadm from ${url}"
+    wget -O "$dest" "$url"
+}
+
+patch_ceph_container_image() {
+    local conf_file="$1"
+    local image tmp
+
+    image=$(ceph_container_image)
+
+    if [ ! -f "$conf_file" ]; then
+        echo "Warning: $conf_file not found, skipping Ceph image patch" >&2
+        return 0
+    fi
+
+    tmp=$(mktemp)
+    grep -v '^quay\.io/ceph/ceph:' "$conf_file" > "$tmp" || true
+    echo "$image" >> "$tmp"
+
+    if [ -w "$conf_file" ]; then
+        mv "$tmp" "$conf_file"
+    else
+        sudo mv "$tmp" "$conf_file"
+    fi
+    echo "Patched Ceph container image in $conf_file -> $image"
+}

--- a/srv_fai_config/files/etc/container_images.conf/SEAPATH_CLUSTER
+++ b/srv_fai_config/files/etc/container_images.conf/SEAPATH_CLUSTER
@@ -2,6 +2,7 @@
 # Format: one image per line as registry/image:tag
 # Lines starting with # are ignored, as well as empty lines
 # This file can be overridden in usercustomization/files/etc/container_images.conf/SEAPATH_CLUSTER
+# The quay.io/ceph/ceph image is injected at build time (see scripts/lib/ceph_version.sh).
+# To pin a version, create usercustomization/class/ceph.version (see ceph.version.example).
 
-quay.io/ceph/ceph:v20.2.0
 docker.io/library/registry:2


### PR DESCRIPTION
Cluster builds used to hardcode Ceph 20.2.0 in build_iso.sh, generate_seapath_image.sh and SEAPATH_CLUSTER. Add a shared helper (scripts/lib/ceph_version.sh) that keeps both artifacts in sync.

By default, the latest release listed on download.ceph.com is used. Users can pin a version locally with usercustomization/class/ceph.version (not tracked by git), or temporarily with the CEPH_VERSION environment variable. The Ceph container image line is injected into SEAPATH_CLUSTER after srv_fai_config and usercustomization are merged.

Document the resolution order in README and add ceph.version.example.